### PR TITLE
Fixed issue where new users would not be recognized after creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,12 @@ services:
 
             # For access by each user
             - /home:/home
-            # Authentication
-            # passwd/group should be mounted into any container
-            # needing to share the user/group IDs
-            - /etc/passwd:/etc/passwd:ro
-            - /etc/group:/etc/group:ro
-            # Shadow should only be mounted into containers
-            # needing to authenticate against PAM
-            - /etc/shadow:/etc/shadow:ro
+            # Authentication cannot mount individual files, because the mapping is
+            # based on the inode
+            # - /etc/passwd:/etc/passwd:ro
+            # - /etc/group:/etc/group:ro
+            # - /etc/shadow:/etc/shadow:ro
+            - /etc:/etc:ro
         ports:
             - 5000:5000
             - 5001:5001


### PR DESCRIPTION
Closes #53

The issue is that file bind mounts are based on the inode number (a number which internally represents a file). Normally, when you edit a file, the inode number is preserved. If you rename a file, the inode number is also preserved. However, if you delete a file and re-create it in the same location, the inode number may change.

The issue is that the passwd process first renames /etc/shadow to a backup file and create a new file with a new inode number to replace it to ensure that the file never gets corrupted. While good for normal operations, the file bind mount still pointing to the old inode number and thus the containers see the outdated file.