### PR TITLE
use generic name for cert files

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -36,8 +36,8 @@ http {
 
     server {
         listen                    443 ssl;
-        ssl_certificate           /certs/fredhutch.org.crt;
-        ssl_certificate_key       /certs/fredhutch.org.key;
+        ssl_certificate           /certs/cert.crt;
+        ssl_certificate_key       /certs/cert.key;
         ssl_session_cache         builtin:1000  shared:SSL:10m;
         ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers               HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;


### PR DESCRIPTION
We don't want anything specific to fredhutch in our configuration. Everything should be generic so that anyone in the world can install Motuz. So I changed the names of the certs to remove fredhutch.org from the names and replace it with cert. 
I will follow up with documentation that references these names. 

**NOTE**: Before you deploy this change you will need to copy (or rename) your certs as follows:

```
cd /root/certs
cp fredhutch.org.crt cert.crt
cp fredhutch.org.key cert.key
```