### PR TITLE
Makedir

### DIFF
--- a/src/backend/api/managers/system_manager.py
+++ b/src/backend/api/managers/system_manager.py
@@ -20,7 +20,7 @@ def get_uid():
 
 
 @token_required
-def get_files(data):
+def ls(data):
     path = data['path']
     connection_id = data['connection_id']
 
@@ -33,6 +33,27 @@ def get_files(data):
     # does not exist, the line above will raise the correct HTTP 4xx Exception
 
     return _get_remote_files(cloud_connection, path)
+
+
+@token_required
+def mkdir(data):
+    path = data['path']
+    connection_id = data['connection_id']
+
+    if connection_id == 0:
+        raise HTTP_400_BAD_REQUEST("Cannot create local folder")
+
+    cloud_connection = cloud_connection_manager.retrieve(connection_id)
+
+    # If user does not have permission to the cloud_connection or if the cloud_connection
+    # does not exist, the line above will raise the correct HTTP 4xx Exception
+
+    connection = RcloneConnection(
+        type=cloud_connection.type,
+        data=cloud_connection,
+    )
+
+    return connection.mkdir(path=path)
 
 
 def _get_local_files(path):

--- a/src/backend/api/views/system_views.py
+++ b/src/backend/api/views/system_views.py
@@ -24,7 +24,21 @@ class SystemFiles(Resource):
         """
         data = request.json
         try:
-            return system_manager.get_files(data), 200
+            return system_manager.ls(data), 200
+        except HTTP_EXCEPTION as e:
+            api.abort(e.code, e.payload)
+
+
+@api.route('/files/mkdir/')
+class SystemFiles(Resource):
+    @api.expect(dto, validate=True)
+    def post(self):
+        """
+        List all files for a particular URI.
+        """
+        data = request.json
+        try:
+            return system_manager.mkdir(data), 200
         except HTTP_EXCEPTION as e:
             api.abort(e.code, e.payload)
 

--- a/src/frontend/js/actions/apiActions.jsx
+++ b/src/frontend/js/actions/apiActions.jsx
@@ -1,6 +1,8 @@
 import { RSAA } from 'redux-api-middleware';
 
 import { withAuth } from 'reducers/reducers.jsx';
+import * as pane from 'actions/paneActions.jsx'
+import * as dialog from 'actions/dialogActions.jsx'
 
 export const LIST_FILES_REQUEST = '@@api/LIST_FILES_REQUEST';
 export const LIST_FILES_SUCCESS = '@@api/LIST_FILES_SUCCESS';
@@ -71,7 +73,15 @@ export const listFiles = (side, data) => ({
 });
 
 
-export const makeDirectory = (data) => ({
+export const makeDirectory = (data) => {
+    return async (dispatch, getState) => {
+        await dispatch(_makeDirectory(data));
+        await dispatch(dialog.hideMkdirDialog())
+        await dispatch(pane.refreshPanes())
+    }
+}
+
+export const _makeDirectory = (data) => ({
     [RSAA]: {
         endpoint: `/api/system/files/mkdir/`,
         method: 'POST',

--- a/src/frontend/js/actions/apiActions.jsx
+++ b/src/frontend/js/actions/apiActions.jsx
@@ -6,6 +6,10 @@ export const LIST_FILES_REQUEST = '@@api/LIST_FILES_REQUEST';
 export const LIST_FILES_SUCCESS = '@@api/LIST_FILES_SUCCESS';
 export const LIST_FILES_FAILURE = '@@api/LIST_FILES_FAILURE';
 
+export const MAKE_DIRECTORY_REQUEST = '@@api/MAKE_DIRECTORY_REQUEST';
+export const MAKE_DIRECTORY_SUCCESS = '@@api/MAKE_DIRECTORY_SUCCESS';
+export const MAKE_DIRECTORY_FAILURE = '@@api/MAKE_DIRECTORY_FAILURE';
+
 export const LIST_COPY_JOBS_REQUEST = '@@api/LIST_COPY_JOBS_REQUEST';
 export const LIST_COPY_JOBS_SUCCESS = '@@api/LIST_COPY_JOBS_SUCCESS';
 export const LIST_COPY_JOBS_FAILURE = '@@api/LIST_COPY_JOBS_FAILURE';
@@ -63,6 +67,17 @@ export const listFiles = (side, data) => ({
                 meta: {side, data},
             },
         ]
+    }
+});
+
+
+export const makeDirectory = (data) => ({
+    [RSAA]: {
+        endpoint: `/api/system/files/mkdir/`,
+        method: 'POST',
+        body: JSON.stringify(data),
+        headers: withAuth({ 'Content-Type': 'application/json' }),
+        types: [ MAKE_DIRECTORY_REQUEST, MAKE_DIRECTORY_SUCCESS, MAKE_DIRECTORY_FAILURE ],
     }
 });
 

--- a/src/frontend/js/actions/dialogActions.jsx
+++ b/src/frontend/js/actions/dialogActions.jsx
@@ -22,6 +22,9 @@ export const HIDE_NEW_CLOUD_CONNECTION_DIALOG = '@@dialog/HIDE_NEW_CLOUD_CONNECT
 export const SHOW_EDIT_CLOUD_CONNECTION_DIALOG = '@@dialog/SHOW_EDIT_CLOUD_CONNECTION_DIALOG';
 export const HIDE_EDIT_CLOUD_CONNECTION_DIALOG = '@@dialog/HIDE_EDIT_CLOUD_CONNECTION_DIALOG';
 
+export const SHOW_MKDIR_DIALOG = '@@dialog/SHOW_MKDIR_DIALOG';
+export const HIDE_MKDIR_DIALOG = '@@dialog/HIDE_MKDIR_DIALOG';
+
 
 export const showCopyJobDialog = () => {
     return async (dispatch, getState) => {
@@ -82,4 +85,24 @@ export const showEditCloudConnectionDialog = (data) => ({
 
 export const hideEditCloudConnectionDialog = () => ({
     type: HIDE_EDIT_CLOUD_CONNECTION_DIALOG,
+});
+
+export const showMkdirDialog = (data) => {
+    return async (dispatch, getState) => {
+        const state = getState();
+        const pane = getCurrentPane(state.pane);
+
+        const {host, path} = pane;
+
+        dispatch({
+            type: SHOW_MKDIR_DIALOG,
+            payload: {
+                data: {host, path}
+            },
+        })
+    }
+};
+
+export const hideMkdirDialog = () => ({
+    type: HIDE_MKDIR_DIALOG,
 });

--- a/src/frontend/js/components/ToolButtons.jsx
+++ b/src/frontend/js/components/ToolButtons.jsx
@@ -13,11 +13,10 @@ class ToolButtons extends React.Component {
             <React.Fragment>
                 <button
                     className="btn btn-outline-primary my-2 ml-2 my-sm-0"
-                    onClick={event => this.props.onToggleShowHiddenFiles()}
+                    onClick={event => this.props.onShowMkdirDialog()}
                     alt='Create Folder'
                     title='Create Folder'
                     aria-label='Create Folder'
-                    style={{display: 'none'}}
                 >
                     <Icon name='file-submodule'/>
                 </button>
@@ -58,18 +57,21 @@ class ToolButtons extends React.Component {
 
 ToolButtons.defaultProps = {
     showHiddenFiles: true,
+    onShowMkdirDialog: () => {},
     onRefresh: () => {},
     onToggleShowHiddenFiles: () => {},
 }
 
 import {connect} from 'react-redux';
 import {toggleShowHiddenFiles, refreshPanes} from 'actions/paneActions.jsx';
+import {showMkdirDialog} from 'actions/dialogActions.jsx'
 
 const mapStateToProps = state => ({
     showHiddenFiles: state.pane.showHiddenFiles,
 });
 
 const mapDispatchToProps = dispatch => ({
+    onShowMkdirDialog: () => dispatch(showMkdirDialog()),
     onRefresh: () => dispatch(refreshPanes()),
     onToggleShowHiddenFiles: () => dispatch(toggleShowHiddenFiles()),
 });

--- a/src/frontend/js/reducers/alertReducer.jsx
+++ b/src/frontend/js/reducers/alertReducer.jsx
@@ -26,7 +26,7 @@ export default (state=initialState, action) => {
     case api.CREATE_CLOUD_CONNECTION_FAILURE:
     case api.UPDATE_CLOUD_CONNECTION_FAILURE:
     case api.DELETE_CLOUD_CONNECTION_FAILURE:
-
+    case api.MAKE_DIRECTORY_FAILURE:
     {
         return {
             ...state,

--- a/src/frontend/js/reducers/dialogReducer.jsx
+++ b/src/frontend/js/reducers/dialogReducer.jsx
@@ -33,7 +33,9 @@ const initialState = {
     editCloudConnectionDialogData: {},
 
     displayMkdirDialog: false,
-    mkdirDialogData: {},
+    mkdirDialogData: {
+        loading: false,
+    },
 };
 
 export default (state=initialState, action) => {
@@ -168,6 +170,28 @@ export default (state=initialState, action) => {
         return {
             ...state,
             displayMkdirDialog: false,
+            mkdirDialogData: initialState.mkdirDialogData,
+        }
+    }
+
+    case api.MAKE_DIRECTORY_REQUEST: {
+        return {
+            ...state,
+            mkdirDialogData: {
+                ...state.mkdirDialogData,
+                loading: true,
+            }
+        }
+    }
+    case api.MAKE_DIRECTORY_SUCCESS:
+    case api.MAKE_DIRECTORY_FAILURE:
+    {
+        return {
+            ...state,
+            mkdirDialogData: {
+                ...state.mkdirDialogData,
+                loading: false,
+            }
         }
     }
 

--- a/src/frontend/js/reducers/dialogReducer.jsx
+++ b/src/frontend/js/reducers/dialogReducer.jsx
@@ -30,7 +30,10 @@ const initialState = {
     },
 
     displayEditCloudConnectionDialog: false,
-    editCloudConnectionDialogData: {}
+    editCloudConnectionDialogData: {},
+
+    displayMkdirDialog: false,
+    mkdirDialogData: {},
 };
 
 export default (state=initialState, action) => {
@@ -146,6 +149,25 @@ export default (state=initialState, action) => {
                 verifyFinished: true,
                 verifySuccess: false,
             }
+        }
+    }
+
+
+    case dialog.SHOW_MKDIR_DIALOG: {
+        return {
+            ...state,
+            displayMkdirDialog: true,
+            mkdirDialogData: {
+                ...state.mkdirDialogData,
+                ...action.payload.data,
+            }
+        }
+    }
+
+    case dialog.HIDE_MKDIR_DIALOG: {
+        return {
+            ...state,
+            displayMkdirDialog: false,
         }
     }
 

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -15,8 +15,8 @@ import {
 const INITIAL_PANE = {
     host: {
         id: 0,
-        name: '127.0.0.1',
-        type: 'localhost',
+        name: 'localhost',
+        type: 'file',
         access_key_id: '',
         access_key_secret: '',
         region: '',

--- a/src/frontend/js/views/App/CommandBar/CommandBar.jsx
+++ b/src/frontend/js/views/App/CommandBar/CommandBar.jsx
@@ -121,8 +121,8 @@ class CommandBar extends React.Component {
         const clouds = [
             {
                 id: 0,
-                name: '127.0.0.1',
-                type: 'localhost',
+                name: 'localhost',
+                type: 'file',
             },
             ...this.props.clouds
         ];

--- a/src/frontend/js/views/Dialogs/CopyJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/CopyJobDialog.jsx
@@ -7,6 +7,7 @@ import serializeForm from 'utils/serializeForm.jsx'
 class CopyJobDialog extends React.Component {
     constructor(props) {
         super(props);
+        this.inputRef = React.createRef()
     }
 
     render() {
@@ -78,7 +79,7 @@ class CopyJobDialog extends React.Component {
                                             name="description"
                                             type="text"
                                             className="form-control"
-                                            autoFocus
+                                            ref={this.inputRef}
                                         />
                                     </div>
                                     <div className="col-1"></div>
@@ -129,7 +130,7 @@ class CopyJobDialog extends React.Component {
     }
 
     componentDidMount() {
-
+        this.inputRef.current.focus()
     }
 }
 

--- a/src/frontend/js/views/Dialogs/Dialogs.jsx
+++ b/src/frontend/js/views/Dialogs/Dialogs.jsx
@@ -4,6 +4,7 @@ import CopyJobDialog from 'views/Dialogs/CopyJobDialog.jsx';
 import CopyJobEditDialog from 'views/Dialogs/CopyJobEditDialog.jsx';
 import NewCloudConnectionDialog from 'views/Dialogs/NewCloudConnectionDialog.jsx';
 import EditCloudConnectionDialog from 'views/Dialogs/EditCloudConnectionDialog.jsx';
+import MkdirDialog from 'views/Dialogs/MkdirDialog.jsx';
 
 class Dialogs extends React.Component {
     constructor(props) {
@@ -17,6 +18,7 @@ class Dialogs extends React.Component {
                 {this.props.dialogs.displayCopyJobEditDialog && <CopyJobEditDialog />}
                 {this.props.dialogs.displayNewCloudConnectionDialog && <NewCloudConnectionDialog />}
                 {this.props.dialogs.displayEditCloudConnectionDialog && <EditCloudConnectionDialog />}
+                {this.props.dialogs.displayMkdirDialog && <MkdirDialog />}
             </React.Fragment>
         );
     }

--- a/src/frontend/js/views/Dialogs/MkdirDialog.jsx
+++ b/src/frontend/js/views/Dialogs/MkdirDialog.jsx
@@ -11,7 +11,7 @@ class MkdirDialog extends React.Component {
     }
 
     render() {
-        const { host, path } = this.props.data;
+        const { host, path, loading } = this.props.data;
         const uri = `${host.type}://${path}`
 
         return (
@@ -64,7 +64,7 @@ class MkdirDialog extends React.Component {
                             <Button variant="secondary" onClick={() => this.handleClose()}>
                                 Cancel
                             </Button>
-                            <Button variant="primary" type='submit'>
+                            <Button variant="primary" type='submit' disabled={loading}>
                                 Make Directory
                             </Button>
                         </Modal.Footer>

--- a/src/frontend/js/views/Dialogs/MkdirDialog.jsx
+++ b/src/frontend/js/views/Dialogs/MkdirDialog.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import { Modal, Button } from 'react-bootstrap'
+
+import serializeForm from 'utils/serializeForm.jsx'
+
+class MkdirDialog extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        const { host, path } = this.props.data;
+        const uri = `${host.type}://${path}`
+
+        return (
+            <div className='dialog-copy-job'>
+                <Modal
+                    show={true}
+                    size="lg"
+                    onHide={() => this.handleClose()}
+                >
+                    <form action="#" onSubmit={(event) => this.handleSubmit(event)}>
+                        <Modal.Header closeButton>
+                            <Modal.Title>Make Directory</Modal.Title>
+                        </Modal.Header>
+                        <Modal.Body>
+                            <div className="container">
+                                <input
+                                    type="hidden"
+                                    name="connection_id"
+                                    value={host.id}
+                                />
+                                <div className="row form-group">
+                                    <div className="col-4 text-right">
+                                        <b>Path</b>
+                                    </div>
+                                    <div className="col-7">
+                                        <b>{host.type}</b>
+                                        <span>://</span>
+                                        <span>{path}</span>
+                                    </div>
+                                    <input type="hidden" name="path_prefix" value={path}/>
+                                    <div className="col-1"></div>
+                                </div>
+                                <div className="row form-group">
+                                    <div className="col-4 text-right">
+                                        <b>Directory Name</b>
+                                    </div>
+                                    <div className="col-7">
+                                        <input
+                                            className="form-control"
+                                            type="text"
+                                            name="path_suffix"
+                                        />
+                                    </div>
+                                    <div className="col-1"></div>
+                                </div>
+                            </div>
+                        </Modal.Body>
+                        <Modal.Footer>
+                            <Button variant="secondary" onClick={() => this.handleClose()}>
+                                Cancel
+                            </Button>
+                            <Button variant="primary" type='submit'>
+                                Make Directory
+                            </Button>
+                        </Modal.Footer>
+                    </form>
+                </Modal>
+            </div>
+        );
+    }
+
+    handleClose() {
+        this.props.onClose();
+    }
+
+    handleSubmit(event) {
+        event.preventDefault();
+
+        const form_data = serializeForm(event.target)
+
+        const data = {
+            path: `${form_data.path_prefix}/${form_data.path_suffix}`,
+            connection_id: window.parseInt(form_data.connection_id),
+        }
+
+        this.props.onSubmit(data);
+    }
+
+    componentDidMount() {
+
+    }
+}
+
+MkdirDialog.defaultProps = {
+    data: {},
+    onClose: () => {},
+    onSubmit: (data) => {},
+}
+
+import {connect} from 'react-redux';
+import {hideMkdirDialog} from 'actions/dialogActions.jsx'
+import {makeDirectory} from 'actions/apiActions.jsx'
+
+const mapStateToProps = state => ({
+    data: state.dialog.mkdirDialogData,
+});
+
+const mapDispatchToProps = dispatch => ({
+    onClose: () => dispatch(hideMkdirDialog()),
+    onSubmit: data => dispatch(makeDirectory(data)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(MkdirDialog);

--- a/src/frontend/js/views/Dialogs/MkdirDialog.jsx
+++ b/src/frontend/js/views/Dialogs/MkdirDialog.jsx
@@ -7,6 +7,7 @@ import serializeForm from 'utils/serializeForm.jsx'
 class MkdirDialog extends React.Component {
     constructor(props) {
         super(props);
+        this.inputRef = React.createRef()
     }
 
     render() {
@@ -52,6 +53,7 @@ class MkdirDialog extends React.Component {
                                             className="form-control"
                                             type="text"
                                             name="path_suffix"
+                                            ref={this.inputRef}
                                         />
                                     </div>
                                     <div className="col-1"></div>
@@ -90,7 +92,7 @@ class MkdirDialog extends React.Component {
     }
 
     componentDidMount() {
-
+        this.inputRef.current.focus()
     }
 }
 

--- a/src/frontend/js/views/Dialogs/NewCloudConnectionDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewCloudConnectionDialog.jsx
@@ -65,7 +65,9 @@ class NewCloudConnectionDialog extends React.Component {
                     </Modal.Header>
                     <Modal.Body>
                             <CloudConnectionDialogFields
-                                data={{}}
+                                data={{
+                                    s3_region: 'us-west-2'
+                                }}
                                 errors={errors}
                                 verifySuccess={(verifyFinished && verifySuccess)}
                             />

--- a/src/frontend/js/views/Dialogs/NewCloudConnectionDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewCloudConnectionDialog.jsx
@@ -22,7 +22,8 @@ class NewCloudConnectionDialog extends React.Component {
             verificationStatusButton = (
                 <Button
                     variant='outline-warning'
-                    className='ml-2 disabled'
+                    className='ml-2'
+                    disabled
                 >
                     Verifying...
                 </Button>
@@ -31,7 +32,8 @@ class NewCloudConnectionDialog extends React.Component {
             verificationStatusButton = (
                 <Button
                     variant='outline-success'
-                    className='ml-2 disabled'
+                    className='ml-2'
+                    disabled
                 >
                     <Icon name='check'/>
                     <span> Correct </span>
@@ -41,7 +43,8 @@ class NewCloudConnectionDialog extends React.Component {
             verificationStatusButton = (
                 <Button
                     variant='outline-danger'
-                    className='ml-2 disabled'
+                    className='ml-2'
+                    disabled
                 >
                     <Icon name='x'/>
                     <span> Incorrect </span>


### PR DESCRIPTION
Closes #57 


## Notice
**!! The current solution creates a file called `.keep` inside the folder. This is not ideal, but it works for now. !!**


## Tested

- S3
- S3 Compatible Swift storage
- Swift
- Azure

## Mkdir dialog

![Screen Shot 2019-07-04 at 20 42 53](https://user-images.githubusercontent.com/3248682/60696847-5fbfc180-9e9c-11e9-8664-41d70c7fcf8c.png)

## Research

There was a proposed solution for creating folders on the remotes, but I could not get it to work with rclone.

Reference proposed solution:

https://stackoverflow.com/questions/1939743/amazon-s3-boto-how-to-create-a-folder/47821387#47821387

Code for proposed solution:

```
import boto3
s3 = boto3.client('s3')
bucket_name = "fh-the-bucket"
directory_name = "DIRECTORY/THAT/YOU/WANT/TO/CREATE"
s3.put_object(Bucket=bucket_name, Key=(directory_name+'/'))
```

What was tried:

```
$ rclone touch motuz_azure:/cloudmoverblobs/bar/
2019/07/04 19:45:37 "motuz_azure:/cloudmoverblobs/bar/" is a directory
```

There is also an `rclone mkdir` command, but it is used solely for creating buckets. It does not create folders within those buckets.