### PR TITLE
Improved performance of copy jobs

### DIFF
--- a/src/backend/api/managers/copy_job_manager.py
+++ b/src/backend/api/managers/copy_job_manager.py
@@ -16,15 +16,6 @@ def list():
     owner = get_logged_in_user(request)
 
     copy_jobs = CopyJob.query.filter_by(owner=owner).all()
-
-    for copy_job in copy_jobs:
-        try:
-            task = tasks.copy_job.AsyncResult(str(copy_job.id))
-            copy_job.progress_text = task.info.get('text', '')
-            copy_job.progress_error_text = task.info.get('error_text', '')
-        except Exception:
-            pass # Sometimes rabbitmq closes the connection!
-
     return copy_jobs
 
 

--- a/src/frontend/js/actions/dialogActions.jsx
+++ b/src/frontend/js/actions/dialogActions.jsx
@@ -59,12 +59,10 @@ export const hideNewCopyJobDialog = () => ({
 });
 
 
-export const showEditCopyJobDialog = (copyJob) => {
-    return {
-        type: SHOW_EDIT_COPY_JOB_DIALOG,
-        payload: copyJob,
-    }
-};
+export const showEditCopyJobDialog = (copyJob) => ({
+    type: SHOW_EDIT_COPY_JOB_DIALOG,
+    payload: copyJob,
+});
 
 export const hideEditCopyJobDialog = () => ({
     type: HIDE_EDIT_COPY_JOB_DIALOG,

--- a/src/frontend/js/actions/dialogActions.jsx
+++ b/src/frontend/js/actions/dialogActions.jsx
@@ -59,9 +59,9 @@ export const hideNewCopyJobDialog = () => ({
 });
 
 
-export const showEditCopyJobDialog = (jobId) => ({
+export const showEditCopyJobDialog = (copyJob) => ({
     type: SHOW_EDIT_COPY_JOB_DIALOG,
-    payload: {data: {id: jobId}},
+    payload: {data: {id: copyJob.id}},
 });
 
 export const hideEditCopyJobDialog = () => ({

--- a/src/frontend/js/actions/dialogActions.jsx
+++ b/src/frontend/js/actions/dialogActions.jsx
@@ -59,10 +59,12 @@ export const hideNewCopyJobDialog = () => ({
 });
 
 
-export const showEditCopyJobDialog = (copyJob) => ({
-    type: SHOW_EDIT_COPY_JOB_DIALOG,
-    payload: {data: {id: copyJob.id}},
-});
+export const showEditCopyJobDialog = (copyJob) => {
+    return {
+        type: SHOW_EDIT_COPY_JOB_DIALOG,
+        payload: copyJob,
+    }
+};
 
 export const hideEditCopyJobDialog = () => ({
     type: HIDE_EDIT_COPY_JOB_DIALOG,

--- a/src/frontend/js/reducers/dialogReducer.jsx
+++ b/src/frontend/js/reducers/dialogReducer.jsx
@@ -59,11 +59,14 @@ export default (state=initialState, action) => {
         }
     }
 
-    case dialog.SHOW_EDIT_COPY_JOB_DIALOG: {
+    case dialog.SHOW_EDIT_COPY_JOB_DIALOG:
+    case api.RETRIEVE_COPY_JOB_SUCCESS:
+    case api.STOP_COPY_JOB_SUCCESS:
+    {
         return {
             ...state,
             displayEditCopyJobDialog: true,
-            editCopyJobDialogData: action.payload.data,
+            editCopyJobDialogData: action.payload,
         }
     }
 

--- a/src/frontend/js/reducers/dialogReducer.jsx
+++ b/src/frontend/js/reducers/dialogReducer.jsx
@@ -63,6 +63,10 @@ export default (state=initialState, action) => {
     case api.RETRIEVE_COPY_JOB_SUCCESS:
     case api.STOP_COPY_JOB_SUCCESS:
     {
+        if (state.editCopyJobDialogData.progress_state === 'STOPPED') {
+            return state; // Do not overwrite STOPPED due to race condition
+        }
+
         return {
             ...state,
             displayEditCopyJobDialog: true,

--- a/src/frontend/js/reducers/dialogReducer.jsx
+++ b/src/frontend/js/reducers/dialogReducer.jsx
@@ -63,8 +63,13 @@ export default (state=initialState, action) => {
     case api.RETRIEVE_COPY_JOB_SUCCESS:
     case api.STOP_COPY_JOB_SUCCESS:
     {
-        if (state.editCopyJobDialogData.progress_state === 'STOPPED') {
-            return state; // Do not overwrite STOPPED due to race condition
+        if (
+            state.editCopyJobDialogData.progress_state === 'STOPPED' &&
+            action.payload.progress_state === 'PROGRESS'
+        ) {
+            // TODO: This is a bit of a hack
+            // Do not overwrite STOPPED due to race condition
+            return state;
         }
 
         return {
@@ -79,6 +84,7 @@ export default (state=initialState, action) => {
         return {
             ...state,
             displayEditCopyJobDialog: false,
+            editCopyJobDialogData: initialState.editCopyJobDialogData,
         }
     }
 

--- a/src/frontend/js/views/App/CopyJobSection/CopyJobTable.jsx
+++ b/src/frontend/js/views/App/CopyJobSection/CopyJobTable.jsx
@@ -161,7 +161,8 @@ class CopyJobTable extends React.Component {
     }
 
     _onSelectJob(selectedJob) {
-        this.props.onShowDetails(selectedJob.id);
+        console.log(selectedJob)
+        this.props.onShowDetails(selectedJob);
     }
 
     _clearTimeout() {
@@ -178,7 +179,7 @@ CopyJobTable.defaultProps = {
     fetchData: () => {},
     refreshPanes: () => {},
     onStopJob: id => {},
-    onShowDetails: (jobId) => {},
+    onShowDetails: (copyJob) => {},
 }
 
 import {connect} from 'react-redux';
@@ -195,7 +196,7 @@ const mapDispatchToProps = dispatch => ({
     fetchData: () => dispatch(listCopyJobs()),
     refreshPanes: () => dispatch(refreshPanes()),
     onStopJob: id => dispatch(stopCopyJob(id)),
-    onShowDetails: (jobId) => dispatch(showEditCopyJobDialog(jobId)),
+    onShowDetails: (copyJob) => dispatch(showEditCopyJobDialog(copyJob)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(CopyJobTable);

--- a/src/frontend/js/views/App/CopyJobSection/CopyJobTable.jsx
+++ b/src/frontend/js/views/App/CopyJobSection/CopyJobTable.jsx
@@ -35,6 +35,12 @@ class CopyJobTable extends React.Component {
                 type: 'file',
             }
         }
+
+        if (this.props.connections.length == 0) {
+            // Can happen if connections have not been fetched yet
+            return <div></div>
+        }
+
         this.props.connections.forEach(connection => {
             cloudMapping[connection.id] = connection
         })
@@ -89,7 +95,7 @@ class CopyJobTable extends React.Component {
                 />
             )
 
-            job = {
+            const jobFields = {
                 ...job,
                 time: parseTime(job.progress_execution_time),
                 state,
@@ -105,7 +111,7 @@ class CopyJobTable extends React.Component {
                 >
                     {headers.map((header, j) => (
                         <td key={j}>
-                            {job[header]}
+                            {jobFields[header]}
                         </td>
                     ))}
                 </tr>
@@ -161,7 +167,6 @@ class CopyJobTable extends React.Component {
     }
 
     _onSelectJob(selectedJob) {
-        console.log(selectedJob)
         this.props.onShowDetails(selectedJob);
     }
 


### PR DESCRIPTION
Closes #104

Previously, an API call to `GET /api/copy-job` would take 1.8 - 2.0 seconds for ~ 100 copy jobs returned. This was because each copy job had to be checked against rabbitmq. Rabbitmq stores data about "text" and "error_text". We now only provide this data for `GET /api/copy-job/{id}`, so I restructured the frontend around this limitation. Things are running smooth now and we are seeing 0.050 seconds for the previously 1.8-2.0 `GET /api/copy-job`