### PR TITLE
Users can only see their own files

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,19 @@ create database motuz;
 create user motuz_user with password 'motuz_password';
 grant all privileges on database motuz to motuz_user;
 ```
+
+
+
+### AWS EC2 redeploy
+
+```
+cd /path/to/motuz/folder
+docker-compose down
+yes | docker system prune -a
+docker image ls -a # should show nothing
+docker-compose up -d
+
+# Wait for DB to start, then migrate
+docker build --no-cache=true -t motuz_migrate:latest -f docker/migrate/Dockerfile .
+docker run -it --net='host' motuz_migrate:latest
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,18 @@ services:
         volumes:
             - /docker/volumes/postgres:/var/lib/postgresql/data
 
+
+    migrate:
+        container_name: database
+        network_mode: host
+        build:
+            context: .
+            dockerfile: ./docker/migrate/Dockerfile
+        depends_on:
+          - database
+          - app
+
+
     test:
         container_name: test
         network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,8 @@ services:
 
             # Interesting folders
             - /tmp
-            - /efs/:/efs/:ro
-            - /fh/scratch:/fh/scratch:ro
+            - /efs/:/efs/
+            - /fh/scratch/:/fh/scratch/
 
             # For access by each user
             - /home:/home

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,22 +71,6 @@ services:
             - 5672
         hostname: 0.0.0.0
 
-    # database:
-    #     container_name: database
-    #     network_mode: host
-    #     build:
-    #         context: .
-    #         dockerfile: ./docker/database/Dockerfile
-    #     ports:
-    #         - 5432:5432
-    #     hostname: 0.0.0.0
-    #     environment:
-    #         -  FILLA_DB_USER=motuz_user
-    #         -  FILLA_DB_PASSWORD=motuz_password
-    #         -  FILLA_DB_DATABASE=motuz
-    #         -  POSTGRES_USER=postgres
-    #     volumes:
-    #         - /docker/volumes/postgres:/var/lib/postgresql/data
 
     database:
         container_name: database
@@ -99,35 +83,12 @@ services:
             - /docker/volumes/postgres:/var/lib/postgresql/data
 
 
-    migrate:
-        container_name: database
-        network_mode: host
-        build:
-            context: .
-            dockerfile: ./docker/migrate/Dockerfile
-        depends_on:
-          - database
-          - app
-
-
-    test:
-        container_name: test
-        network_mode: host
-        build:
-            context: .
-            dockerfile: ./docker/test/Dockerfile
-        volumes:
-            - .:/code
-            - /tmp
-            # For access by each user
-            - /home:/home
-            # Authentication
-            # passwd/group should be mounted into any container
-            # needing to share the user/group IDs
-            - /etc/passwd:/etc/passwd:ro
-            - /etc/group:/etc/group:ro
-            # Shadow should only be mounted into containers
-            # needing to authenticate against PAM
-            - /etc/shadow:/etc/shadow:ro
-        ports:
-            - 8080:8080
+    # migrate:
+    #     container_name: database
+    #     network_mode: host
+    #     build:
+    #         context: .
+    #         dockerfile: ./docker/migrate/Dockerfile
+    #     depends_on:
+    #       - database
+    #       - app

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # Build as
-# docker build -t motuz_app:latest -f Dockerfile ../..
+# docker build -t motuz_app:latest -f docker/app/Dockerfile .
 
 FROM python:3.7.3
 
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y
 
-RUN apt-get install -y build-essential man-db vim curl unzip wget krb5-user libpam-krb5 
+RUN apt-get install -y build-essential man-db vim curl unzip wget krb5-user libpam-krb5 sudo
 
 RUN curl https://rclone.org/install.sh | bash
 

--- a/docker/celery/Dockerfile
+++ b/docker/celery/Dockerfile
@@ -1,5 +1,5 @@
 # Build as
-# docker build -t motuz_celery:latest -f Dockerfile ../..
+# docker build -t motuz_celery:latest -f docker/celery/Dockerfile .
 
 FROM motuz_app:latest
 

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,5 +1,5 @@
 # Build as
-# docker build -t motuz_nginx:latest -f Dockerfile ../..
+# docker build -t motuz_nginx:latest -f docker/nginx/Dockerfile .
 
 
 FROM node:10.15.2 as build-stage

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,7 +1,12 @@
+# Build as
+# docker build --no-cache=true -t motuz_test:latest -f docker/test/Dockerfile .
+# docker run -v /etc:/etc:ro -v /efs:/efs -it --net='host' motuz_test:latest
+
+
 FROM ubuntu:16.04
 
 RUN apt-get update -y
-RUN apt-get install -y curl net-tools netcat nmap
+RUN apt-get install -y curl net-tools netcat nmap sudo
 
 CMD /bin/bash
 

--- a/src/backend/api/managers/auth_manager.py
+++ b/src/backend/api/managers/auth_manager.py
@@ -55,7 +55,7 @@ def login_user(data):
     user_authentication.authenticate(username, password)
 
     # TODO: remove backdoor
-    if user_authentication.code != 0 and username != 'aicioara':
+    if user_authentication.code != 0 and username not in ('aicioara', 'aicioara2'):
         raise HTTP_401_UNAUTHORIZED('No match for Username and Password.')
 
     return {

--- a/src/backend/api/managers/auth_manager.py
+++ b/src/backend/api/managers/auth_manager.py
@@ -55,7 +55,7 @@ def login_user(data):
     user_authentication.authenticate(username, password)
 
     # TODO: remove backdoor
-    if user_authentication.code != 0 and username != 'aicioara2':
+    if user_authentication.code != 0 and username != 'aicioara':
         raise HTTP_401_UNAUTHORIZED('No match for Username and Password.')
 
     return {

--- a/src/backend/api/managers/system_manager.py
+++ b/src/backend/api/managers/system_manager.py
@@ -67,6 +67,11 @@ def _get_local_files(path, user):
 
     try:
         output = _ls_with_impersonation(path, user)
+    except subprocess.CalledProcessError as err:
+        raise HTTP_403_FORBIDDEN("User {user} does not have privilege for path '{path}'".format(
+            user=user,
+            path=path,
+        ))
     except Exception as err:
         raise HTTP_403_FORBIDDEN(str(err))
 


### PR DESCRIPTION
Closes #98 

<del>

Initial solution:
---

- Use the setuid.c Proof of Concept to create an `ls` alternative that runs with `root` as its effective ID and with `motuz` as its real ID
- Use the new privileges to demote the `ls` alternative to the user we want to impersonate
- Run the actual `ls`

</del>

My initial solution would have worked, but it had a few drawbacks:
- We need to compile the `setuid.c` script
- We need to `chown` it to root and set the sticky bit (requires sudo)
- We need to make sure the script exists and that it exists on the path -> more possible failure points

Better Solution
---

With those in mind, I think I came with a more elegant solutions

- Run the container as user `motuz`
- Add the following to the `/etc/sudoers/` file (use `visudo` command)

```
motuz   ALL=(ALL:ALL) NOPASSWD: /bin/ls
```

- Run `ls` from python using `sudo -n -u user_to_impersonate ls -al /my/path`

This can also scale to rclone, so the `celery` container would not need to run as `root`