### PR TITLE
Added fallback percentage extraction method

### DIFF
--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -465,10 +465,17 @@ class RcloneConnection(AbstractConnection):
         status = self._job_status[job_id]
 
         match = re.search(r'(\d+)\%', status['GTransferred'])
-        if match is None:
-            self._job_percent[job_id] = -1
-        else:
+
+        if match is not None:
             self._job_percent[job_id] = match[1]
+            return
+
+        match = re.search(r'(\d+)\%', status['Transferred'])
+        if match is not None:
+            self._job_percent[job_id] = match[1]
+            return
+
+        self._job_percent[job_id] = -1
 
 
 


### PR DESCRIPTION
Closes #192

I could not reproduce the actual issue, it all works fine on my machine, but it appears from the screenshot in the bug report that the `GTransferred` field does not get populated properly. I can fix that by fetching the `Transferred` percentage. This is not ideal, because that is just a percentage of the number of files copied, rather than total bytes copied. We should investigate the root cause further.
