### PR TITLE
Implemented better UX for private fields in EditCloudConnection

### DIFF
--- a/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
@@ -312,6 +312,7 @@ class CloudConnectionDialogFields extends React.Component {
                     label='Password / Key'
                     input={{
                         name: 'swift_key',
+                        type: 'password',
                         defaultValue: this.props.data.swift_key,
                         required: true,
                     }}

--- a/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
@@ -93,7 +93,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.name}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 {type === 's3' && this._renderS3Section()}
@@ -122,7 +122,7 @@ class CloudConnectionDialogFields extends React.Component {
                         defaultValue: this.props.data.bucket,
                     }}
                     error={this.props.errors.bucket}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
                 <CloudConnectionField
                     label='Region'
@@ -131,7 +131,7 @@ class CloudConnectionDialogFields extends React.Component {
                         defaultValue: this.props.data.s3_region,
                     }}
                     error={this.props.errors.s3_region}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -144,7 +144,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.s3_access_key_id}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -155,7 +155,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.s3_secret_access_key}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
 
                 <details>
@@ -170,7 +171,7 @@ class CloudConnectionDialogFields extends React.Component {
                             defaultValue: this.props.data.s3_endpoint,
                         }}
                         error={this.props.errors.s3_endpoint}
-                        is_valid={this.props.verifySuccess}
+                        isValid={this.props.verifySuccess}
                     />
                 </details>
 
@@ -218,7 +219,7 @@ class CloudConnectionDialogFields extends React.Component {
                         defaultValue: this.props.data.bucket,
                     }}
                     error={this.props.errors.bucket}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -231,7 +232,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.azure_account}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -242,7 +243,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.azure_key}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
             </React.Fragment>
         )
@@ -257,7 +259,8 @@ class CloudConnectionDialogFields extends React.Component {
                     defaultValue: this.props.data.azure_sas_url,
                 }}
                 error={this.props.errors.azure_sas_url}
-                is_valid={this.props.verifySuccess}
+                isValid={this.props.verifySuccess}
+                isSanitized={this.props.isSanitized}
             />
         )
     }
@@ -272,7 +275,7 @@ class CloudConnectionDialogFields extends React.Component {
                         defaultValue: this.props.data.bucket,
                     }}
                     error={this.props.errors.bucket}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -282,7 +285,7 @@ class CloudConnectionDialogFields extends React.Component {
                         defaultValue: this.props.data.swift_auth,
                     }}
                     error={this.props.errors.swift_auth}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -292,7 +295,7 @@ class CloudConnectionDialogFields extends React.Component {
                         defaultValue: this.props.data.swift_tenant,
                     }}
                     error={this.props.errors.swift_tenant}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -305,7 +308,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.swift_user}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -317,7 +320,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.swift_key}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
             </React.Fragment>
         )
@@ -334,7 +338,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.bucket}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -345,7 +349,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.gcp_project_number}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -358,7 +362,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.gcp_client_id}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -369,7 +373,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.gcp_service_account_credentials}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
 
                 <input
@@ -398,7 +403,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.sftp_host}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -409,7 +414,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.sftp_port}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -420,7 +425,7 @@ class CloudConnectionDialogFields extends React.Component {
                         placeholder: '/',
                     }}
                     error={this.props.errors.bucket}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -433,7 +438,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.sftp_user}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -445,7 +450,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.sftp_pass}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
             </React.Fragment>
         )
@@ -464,7 +470,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.dropbox_token}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
 
 
@@ -513,7 +520,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.onedrive_drive_id}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -524,7 +531,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.onedrive_drive_type}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -537,7 +544,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.onedrive_token}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
 
 
@@ -590,7 +598,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.webdav_url}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
@@ -603,7 +611,7 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.webdav_user}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
                 />
 
                 <CloudConnectionField
@@ -615,7 +623,8 @@ class CloudConnectionDialogFields extends React.Component {
                         required: true,
                     }}
                     error={this.props.errors.webdav_pass}
-                    is_valid={this.props.verifySuccess}
+                    isValid={this.props.verifySuccess}
+                    isSanitized={this.props.isSanitized}
                 />
             </React.Fragment>
         )
@@ -626,6 +635,7 @@ class CloudConnectionDialogFields extends React.Component {
 CloudConnectionDialogFields.defaultProps = {
     verifySuccess: false,
     data: {},
+    isSanitized: false,
 }
 
 CloudConnectionDialogFields.initialState = {
@@ -640,7 +650,8 @@ class CloudConnectionField extends React.PureComponent {
             label,
             input,
             error,
-            is_valid,
+            isValid,
+            isSanitized,
         } = this.props;
 
         return (
@@ -654,10 +665,11 @@ class CloudConnectionField extends React.PureComponent {
                             type="text"
                             className={classnames({
                                 'form-control': true,
-                                'is-valid': is_valid,
+                                'is-valid': isValid,
                                 'is-invalid': error,
                             })}
                             autoComplete='off'
+                            placeholder={isSanitized ? '**********' : null}
                             {...this.props.input}
                         />
                     )}
@@ -668,6 +680,10 @@ class CloudConnectionField extends React.PureComponent {
             </div>
         )
     }
+}
+
+CloudConnectionField.defaultProps = {
+    isSanitized: false,
 }
 
 

--- a/src/frontend/js/views/Dialogs/CloudConnection/EditCloudConnectionDialog.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/EditCloudConnectionDialog.jsx
@@ -41,6 +41,7 @@ class EditCloudConnectionDialog extends React.Component {
                                 data={this.props.data}
                                 errors={this.props.errors}
                                 verifySuccess={(this.props.cloudConnectionVerification.success === true)}
+                                isSanitized={true}
                             />
                     </Modal.Body>
                     <Modal.Footer>

--- a/src/frontend/js/views/Dialogs/CloudConnection/NewCloudConnectionDialog.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/NewCloudConnectionDialog.jsx
@@ -48,6 +48,7 @@ class NewCloudConnectionDialog extends React.Component {
                                 }}
                                 errors={errors}
                                 verifySuccess={(this.props.cloudConnectionVerification.success === true)}
+                                isSanitized={false}
                             />
                     </Modal.Body>
                     <Modal.Footer>


### PR DESCRIPTION
Closes #92

Private Fields (passwords) that are rightfully not returned by the server, are now shown with a placeholder `**********` in the UI to avoid confusion.