### PR TITLE
Fixed bugs when deleting Cloud Connections

### DIFF
--- a/src/backend/api/managers/cloud_connection_manager.py
+++ b/src/backend/api/managers/cloud_connection_manager.py
@@ -15,7 +15,11 @@ from ..managers.auth_manager import token_required, get_logged_in_user
 def list():
     owner = get_logged_in_user(request)
 
-    cloud_connections = CloudConnection.query.filter_by(owner=owner).all()
+    cloud_connections = (CloudConnection.query
+        .filter_by(owner=owner)
+        .order_by(CloudConnection.id.asc())
+        .all()
+    )
     return cloud_connections
 
 

--- a/src/backend/api/models/copy_job.py
+++ b/src/backend/api/models/copy_job.py
@@ -1,6 +1,6 @@
 import datetime
 
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, backref
 
 from ..application import db
 from ..mixins.timestamp_mixin import TimestampMixin
@@ -28,12 +28,12 @@ class CopyJob(db.Model, TimestampMixin):
     src_cloud = relationship(
         "CloudConnection",
         foreign_keys=[src_cloud_id],
-        backref="src_copy_jobs",
+        backref=backref("src_copy_jobs", cascade="all,delete"),
     )
     dst_cloud = relationship(
         "CloudConnection",
         foreign_keys=[dst_cloud_id],
-        backref="dst_copy_jobs",
+        backref=backref("dst_copy_jobs", cascade="all,delete"),
     )
 
     def __repr__(self):

--- a/src/frontend/css/style.css
+++ b/src/frontend/css/style.css
@@ -18,10 +18,6 @@ pre {
     padding: 10px;
 }
 
-body {
-    overflow: hidden;
-}
-
 .octicon {
     width: 16px;
 }

--- a/src/frontend/js/reducers/apiReducer.jsx
+++ b/src/frontend/js/reducers/apiReducer.jsx
@@ -181,6 +181,8 @@ export default (state=initialState, action) => {
     }
     case dialog.HIDE_NEW_CLOUD_CONNECTION_DIALOG:
     case dialog.HIDE_EDIT_CLOUD_CONNECTION_DIALOG:
+    case dialog.SHOW_NEW_CLOUD_CONNECTION_DIALOG:
+    case dialog.SHOW_EDIT_CLOUD_CONNECTION_DIALOG:
     {
         return {
             ...state,

--- a/src/frontend/js/views/App/CopyJobSection/CopyJobTable.jsx
+++ b/src/frontend/js/views/App/CopyJobSection/CopyJobTable.jsx
@@ -56,9 +56,17 @@ class CopyJobTable extends React.Component {
             const dst_cloud_id = job['dst_cloud_id'] || 0
             const dst_cloud = cloudMapping[dst_cloud_id]
 
-            // TODO: We need this in the modal, but this object should ideally be immutable
-            job.src_cloud_type = src_cloud.type;
-            job.dst_cloud_type = dst_cloud.type;
+            if (src_cloud == undefined) {
+                job.src_cloud_type = "(deleted)"
+            } else {
+                job.src_cloud_type = src_cloud.type;
+            }
+
+            if (dst_cloud == undefined) {
+                job.dst_cloud_type = "(deleted)";
+            } else {
+                job.dst_cloud_type = dst_cloud.type;
+            }
 
             let color = 'default';
             if (job.progress_state === 'SUCCESS') {
@@ -75,10 +83,10 @@ class CopyJobTable extends React.Component {
                 </b>
             )
             const source = (
-                <UriResource protocol={src_cloud.type} path={job.src_resource_path} />
+                <UriResource protocol={job.src_cloud_type} path={job.src_resource_path} />
             )
             const destination = (
-                <UriResource protocol={dst_cloud.type} path={job.dst_resource_path} />
+                <UriResource protocol={job.dst_cloud_type} path={job.dst_resource_path} />
             )
             const progress = (
                 <ProgressBar

--- a/src/frontend/js/views/Dialogs/CloudConnection/EditCloudConnectionDialog.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/EditCloudConnectionDialog.jsx
@@ -99,7 +99,9 @@ class EditCloudConnectionDialog extends React.Component {
         const form = this.formRef.current;
         const data = serializeForm(form)
 
-        if (confirm(`Are you sure you want to delete connection ${data.name}`)) {
+        if (confirm(`Are you sure you want to delete connection ${data.name}?\n\n` +
+            `This will delete data for all copy jobs related to this connection.`
+        )) {
             this.props.onDelete(data);
         }
     }


### PR DESCRIPTION
Closes #212 
Closes #217 

- When deleting a cloud connection, all copy jobs to / from that cloud connection are now deleted. Given that we cannot recover much of the information, there is not much point in keeping those records around.
- Fixed a UI crash when the app cached old copy jobs that have been deleted
- Fixed weirdness where Cloud Connections were returned in random order
- Fixed bug where too many cloud connections resulted in some cloud connections being hidden
- Fixed bug where trying to create a new cloud connection after one cloud connection has just been verified and created still had the verification checks on
- Improved the warning message when deleting a cloud connection, such that the user is aware that all copy jobs are also going to be deleted.

