### PR TITLE
Added support for multiple file copy

### DIFF
--- a/src/backend/api/managers/copy_job_manager.py
+++ b/src/backend/api/managers/copy_job_manager.py
@@ -12,10 +12,15 @@ from ..managers.auth_manager import token_required, get_logged_in_user
 
 
 @token_required
-def list():
+def list(page_size=50, offset=0):
     owner = get_logged_in_user(request)
 
-    copy_jobs = CopyJob.query.filter_by(owner=owner).all()
+    copy_jobs = (CopyJob.query
+        .filter_by(owner=owner)
+        .order_by(CopyJob.id.desc())
+        .limit(page_size)
+        .all()
+    )
     return copy_jobs
 
 

--- a/src/backend/api/utils/local_connection.py
+++ b/src/backend/api/utils/local_connection.py
@@ -38,7 +38,7 @@ class LocalConnection(AbstractConnection):
         user = data.owner
 
         try:
-            homePath = _homepath_with_impersonation(user)
+            homePath = _homepath_with_impersonation(user) + "/tmp"
             return self.ls(data, homePath)
         except Exception as e:
             logging.error("User does not have a home", exc_info=True)

--- a/src/backend/api/utils/local_connection.py
+++ b/src/backend/api/utils/local_connection.py
@@ -38,7 +38,7 @@ class LocalConnection(AbstractConnection):
         user = data.owner
 
         try:
-            homePath = _homepath_with_impersonation(user) + "/tmp"
+            homePath = _homepath_with_impersonation(user)
             return self.ls(data, homePath)
         except Exception as e:
             logging.error("User does not have a home", exc_info=True)

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -92,7 +92,7 @@ class RcloneConnection(AbstractConnection):
             '-u', user,
             'rclone',
             'touch',
-            'current:{}/.keep'.format(path),
+            'current:{}/.motuz_keep'.format(path),
         ]
 
         self._logCommand(command, credentials)

--- a/src/backend/api/views/copy_job_views.py
+++ b/src/backend/api/views/copy_job_views.py
@@ -19,7 +19,7 @@ dto = api.model('copy-job', {
     'src_resource_path': fields.String(required=True, example='/tmp'),
     'dst_cloud_id': fields.Integer(required=False, example=2),
     'dst_resource_path': fields.String(required=True, example='/trash'),
-    'owner': fields.String(required=True, example='owner'),
+    'owner': fields.String(required=False, example='owner'),
     'copy_links': fields.Boolean(required=True, example=True),
 
     'progress_state': fields.String(readonly=True, example='PENDING'),

--- a/src/frontend/js/actions/dialogActions.jsx
+++ b/src/frontend/js/actions/dialogActions.jsx
@@ -36,18 +36,27 @@ export const showNewCopyJobDialog = () => {
         const srcSide = getSide(state.pane);
         const srcPane = getCurrentPane(state.pane, srcSide);
         const srcFiles = getCurrentFiles(state.pane, srcSide);
-        const srcResourceName = srcFiles[srcPane.fileFocusIndex].name;
-        const srcResourcePath = upath.join(srcPane.path, srcResourceName)
 
         const dstSide = getOtherSide(srcSide);
         const dstPane = getCurrentPane(state.pane, dstSide)
-        const dstResourcePath = upath.join(dstPane.path, srcResourceName)
+
+        const srcResourcePaths = []
+        const dstResourcePaths = []
+
+        for (let key in srcPane.fileMultiFocusIndexes) {
+            const srcResourceName = srcFiles[Number(key)].name;
+            const srcResourcePath = upath.join(srcPane.path, srcResourceName)
+            const dstResourcePath = upath.join(dstPane.path, srcResourceName)
+
+            srcResourcePaths.push(srcResourcePath)
+            dstResourcePaths.push(dstResourcePath)
+        }
 
         const data = {
             source_cloud: srcPane.host,
-            src_resource_path: srcResourcePath,
+            source_paths: srcResourcePaths,
             destination_cloud: dstPane.host,
-            destination_path: dstResourcePath,
+            destination_paths: dstResourcePaths,
             owner: getCurrentUser(state.auth),
         }
 

--- a/src/frontend/js/actions/paneActions.jsx
+++ b/src/frontend/js/actions/paneActions.jsx
@@ -4,6 +4,7 @@ import { getCurrentPane } from 'managers/paneManager.jsx'
 export const SIDE_FOCUS = '@@pane/SIDE_FOCUS';
 export const FILE_FOCUS_INDEX = '@@pane/FILE_FOCUS_INDEX';
 export const FILE_MULTI_FOCUS_INDEXES = '@@pane/FILE_MULTI_FOCUS_INDEXES';
+export const FILE_RANGE_FOCUS_INDEX = '@@pane/FILE_RANGE_FOCUS_INDEX';
 export const DIRECTORY_CHANGE = '@@pane/DIRECTORY_CHANGE';
 export const HOST_CHANGE = '@@pane/HOST_CHANGE';
 
@@ -16,6 +17,11 @@ export const fileFocusIndex = (side, index) => ({
 export const fileMultiFocusIndexes = (side, indexes) => ({
     type: FILE_MULTI_FOCUS_INDEXES,
     payload: {side, indexes},
+});
+
+export const fileRangeFocusIndex = (side, index) => ({
+    type: FILE_RANGE_FOCUS_INDEX,
+    payload: {side, index},
 });
 
 

--- a/src/frontend/js/actions/paneActions.jsx
+++ b/src/frontend/js/actions/paneActions.jsx
@@ -3,7 +3,7 @@ import { getCurrentPane } from 'managers/paneManager.jsx'
 
 export const SIDE_FOCUS = '@@pane/SIDE_FOCUS';
 export const FILE_FOCUS_INDEX = '@@pane/FILE_FOCUS_INDEX';
-export const FILE_MULTI_FOCUS_INDEXES = '@@pane/FILE_MULTI_FOCUS_INDEXES';
+export const FILE_MULTI_FOCUS_INDEX = '@@pane/FILE_MULTI_FOCUS_INDEX';
 export const FILE_RANGE_FOCUS_INDEX = '@@pane/FILE_RANGE_FOCUS_INDEX';
 export const DIRECTORY_CHANGE = '@@pane/DIRECTORY_CHANGE';
 export const HOST_CHANGE = '@@pane/HOST_CHANGE';
@@ -14,9 +14,9 @@ export const fileFocusIndex = (side, index) => ({
     payload: {side, index},
 });
 
-export const fileMultiFocusIndexes = (side, indexes) => ({
-    type: FILE_MULTI_FOCUS_INDEXES,
-    payload: {side, indexes},
+export const fileMultiFocusIndex = (side, index) => ({
+    type: FILE_MULTI_FOCUS_INDEX,
+    payload: {side, index},
 });
 
 export const fileRangeFocusIndex = (side, index) => ({

--- a/src/frontend/js/actions/paneActions.jsx
+++ b/src/frontend/js/actions/paneActions.jsx
@@ -3,7 +3,7 @@ import { getCurrentPane } from 'managers/paneManager.jsx'
 
 export const SIDE_FOCUS = '@@pane/SIDE_FOCUS';
 export const FILE_FOCUS_INDEX = '@@pane/FILE_FOCUS_INDEX';
-export const FILE_SELECT_INDEXES = '@@pane/FILE_SELECT_INDEXES';
+export const FILE_MULTI_FOCUS_INDEXES = '@@pane/FILE_MULTI_FOCUS_INDEXES';
 export const DIRECTORY_CHANGE = '@@pane/DIRECTORY_CHANGE';
 export const HOST_CHANGE = '@@pane/HOST_CHANGE';
 
@@ -13,8 +13,8 @@ export const fileFocusIndex = (side, index) => ({
     payload: {side, index},
 });
 
-export const fileSelectIndexes = (side, indexes) => ({
-    type: FILE_SELECT_INDEXES,
+export const fileMultiFocusIndexes = (side, indexes) => ({
+    type: FILE_MULTI_FOCUS_INDEXES,
     payload: {side, indexes},
 });
 

--- a/src/frontend/js/actions/paneActions.jsx
+++ b/src/frontend/js/actions/paneActions.jsx
@@ -3,6 +3,7 @@ import { getCurrentPane } from 'managers/paneManager.jsx'
 
 export const SIDE_FOCUS = '@@pane/SIDE_FOCUS';
 export const FILE_FOCUS_INDEX = '@@pane/FILE_FOCUS_INDEX';
+export const FILE_SELECT_INDEXES = '@@pane/FILE_SELECT_INDEXES';
 export const DIRECTORY_CHANGE = '@@pane/DIRECTORY_CHANGE';
 export const HOST_CHANGE = '@@pane/HOST_CHANGE';
 
@@ -10,6 +11,11 @@ export const HOST_CHANGE = '@@pane/HOST_CHANGE';
 export const fileFocusIndex = (side, index) => ({
     type: FILE_FOCUS_INDEX,
     payload: {side, index},
+});
+
+export const fileSelectIndexes = (side, indexes) => ({
+    type: FILE_SELECT_INDEXES,
+    payload: {side, indexes},
 });
 
 

--- a/src/frontend/js/actions/paneActions.jsx
+++ b/src/frontend/js/actions/paneActions.jsx
@@ -14,7 +14,7 @@ export const fileFocusIndex = (side, index) => ({
     payload: {side, index},
 });
 
-export const fileMultiFocusIndex = (side, index) => ({
+export const fileMultiFocusIndexes = (side, index) => ({
     type: FILE_MULTI_FOCUS_INDEX,
     payload: {side, index},
 });

--- a/src/frontend/js/reducers/dialogReducer.jsx
+++ b/src/frontend/js/reducers/dialogReducer.jsx
@@ -6,9 +6,9 @@ const initialState = {
     displayNewCopyJobDialog: false,
     newCopyJobDialogData: {
         source_cloud: {name: 'ERROR'},
-        src_resource_path: 'ERROR',
+        source_paths: ['ERROR'],
         destination_cloud: {name: 'ERROR'},
-        destination_path: 'ERROR',
+        destination_paths: ['ERROR'],
         owner: 'ERROR',
     },
 

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -27,7 +27,7 @@ const INITIAL_PANE = {
     sortingColumn: 'name',
     sortingAsc: true,
     fileFocusIndex: 0,
-    fileMultiFocusIndexes: {},
+    fileMultiFocusIndex: {},
     history: [],
 }
 
@@ -67,23 +67,21 @@ export default (state=initialState, action) => {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
                     fileFocusIndex: index,
-                    fileMultiFocusIndexes: {},
+                    fileMultiFocusIndex: {},
                 }, side)
             }
         }
     }
-    case pane.FILE_MULTI_FOCUS_INDEXES: {
-        const indexes = action.payload.indexes;
+    case pane.FILE_MULTI_FOCUS_INDEX: {
+        const index = action.payload.index;
         const side = action.payload.side || getSide(state);
         const focusPaneLeft = side === 'left';
 
         const currPane = getCurrentPane(state, side)
-        const fileMultiFocusIndexes = {
-            ...currPane.fileMultiFocusIndexes,
+        const fileMultiFocusIndex = {
+            ...currPane.fileMultiFocusIndex,
         }
-        for (let index of indexes) {
-            fileMultiFocusIndexes[index] = true
-        }
+        fileMultiFocusIndex[index] = true
 
         return {
             ...state,
@@ -91,7 +89,7 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,
-                    fileMultiFocusIndexes,
+                    fileMultiFocusIndex,
                 }, side)
             }
         }
@@ -102,13 +100,13 @@ export default (state=initialState, action) => {
         const focusPaneLeft = side === 'left';
 
         const currPane = getCurrentPane(state, side)
-        const fileMultiFocusIndexes = {
-            ...currPane.fileMultiFocusIndexes,
+        const fileMultiFocusIndex = {
+            ...currPane.fileMultiFocusIndex,
         }
         const start = Math.min(currPane.fileFocusIndex, index)
         const end = Math.max(currPane.fileFocusIndex, index)
         for (let i = start; i <= end; i++) {
-            fileMultiFocusIndexes[i] = true
+            fileMultiFocusIndex[i] = true
         }
 
         console.log(start, end)
@@ -119,7 +117,7 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,
-                    fileMultiFocusIndexes,
+                    fileMultiFocusIndex,
                 }, side)
             }
         }

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -137,7 +137,8 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
-                    fileFocusIndex: 0,
+                    fileFocusIndex: initialState.fileFocusIndex,
+                    fileMultiFocusIndex: initialState.fileMultiFocusIndexes,
                     path,
                 }, side)
             },
@@ -170,7 +171,8 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
-                    fileFocusIndex: 0,
+                    fileFocusIndex: initialState.fileFocusIndex,
+                    fileMultiFocusIndex: initialState.fileMultiFocusIndexes,
                     path,
                     host,
                 }, side)

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -27,7 +27,7 @@ const INITIAL_PANE = {
     sortingColumn: 'name',
     sortingAsc: true,
     fileFocusIndex: 0,
-    fileMultiFocusIndex: {},
+    fileMultiFocusIndex: {0: true},
     history: [],
 }
 
@@ -67,7 +67,7 @@ export default (state=initialState, action) => {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
                     fileFocusIndex: index,
-                    fileMultiFocusIndex: {},
+                    fileMultiFocusIndex: {[index]: true},
                 }, side)
             }
         }
@@ -75,20 +75,19 @@ export default (state=initialState, action) => {
     case pane.FILE_MULTI_FOCUS_INDEX: {
         const index = action.payload.index;
         const side = action.payload.side || getSide(state);
-        const focusPaneLeft = side === 'left';
 
         const currPane = getCurrentPane(state, side)
         const fileMultiFocusIndex = {
             ...currPane.fileMultiFocusIndex,
+            [index]: true,
         }
-        fileMultiFocusIndex[index] = true
 
         return {
             ...state,
-            focusPaneLeft,
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,
+                    fileFocusIndex: index,
                     fileMultiFocusIndex,
                 }, side)
             }
@@ -97,7 +96,6 @@ export default (state=initialState, action) => {
     case pane.FILE_RANGE_FOCUS_INDEX: {
         const index = action.payload.index;
         const side = action.payload.side || getSide(state);
-        const focusPaneLeft = side === 'left';
 
         const currPane = getCurrentPane(state, side)
         const fileMultiFocusIndex = {
@@ -113,7 +111,6 @@ export default (state=initialState, action) => {
 
         return {
             ...state,
-            focusPaneLeft,
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -67,6 +67,31 @@ export default (state=initialState, action) => {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
                     fileFocusIndex: index,
+                    fileSelectedIndexes: {},
+                }, side)
+            }
+        }
+    }
+    case pane.FILE_SELECT_INDEXES: {
+        const indexes = action.payload.indexes;
+        const side = action.payload.side || getSide(state);
+        const focusPaneLeft = side === 'left';
+
+        const currPane = getCurrentPane(state, side)
+        const fileSelectedIndexes = {
+            ...currPane.fileSelectedIndexes,
+        }
+        for (let index of indexes) {
+            fileSelectedIndexes[index] = true
+        }
+
+        return {
+            ...state,
+            focusPaneLeft,
+            panes: {
+                ...setCurrentPane(state, {
+                    ...currPane,
+                    fileSelectedIndexes,
                 }, side)
             }
         }

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -27,8 +27,8 @@ const INITIAL_PANE = {
     sortingColumn: 'name',
     sortingAsc: true,
     fileFocusIndex: 0,
+    fileMultiFocusIndexes: {},
     history: [],
-    fileSelectedIndexes: {},
 }
 
 const initialState = {
@@ -67,22 +67,22 @@ export default (state=initialState, action) => {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
                     fileFocusIndex: index,
-                    fileSelectedIndexes: {},
+                    fileMultiFocusIndexes: {},
                 }, side)
             }
         }
     }
-    case pane.FILE_SELECT_INDEXES: {
+    case pane.FILE_MULTI_FOCUS_INDEXES: {
         const indexes = action.payload.indexes;
         const side = action.payload.side || getSide(state);
         const focusPaneLeft = side === 'left';
 
         const currPane = getCurrentPane(state, side)
-        const fileSelectedIndexes = {
-            ...currPane.fileSelectedIndexes,
+        const fileMultiFocusIndexes = {
+            ...currPane.fileMultiFocusIndexes,
         }
         for (let index of indexes) {
-            fileSelectedIndexes[index] = true
+            fileMultiFocusIndexes[index] = true
         }
 
         return {
@@ -91,7 +91,7 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,
-                    fileSelectedIndexes,
+                    fileMultiFocusIndexes,
                 }, side)
             }
         }

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -77,9 +77,21 @@ export default (state=initialState, action) => {
         const side = action.payload.side || getSide(state);
 
         const currPane = getCurrentPane(state, side)
-        const fileMultiFocusIndex = {
-            ...currPane.fileMultiFocusIndex,
-            [index]: true,
+        const fileMultiFocusIndex = {...currPane.fileMultiFocusIndex}
+        let fileFocusIndex = index
+        if (fileMultiFocusIndex[index]) { // Action is deselection
+            if (currPane.fileFocusIndex === index) { // The latest selected file
+                const keys = Object.keys(fileMultiFocusIndex).map(Number)
+                if (keys.length <= 1) {
+                    return state // At least one item should always be selected
+                }
+                fileFocusIndex = keys.filter(d => d !== index)[0] // keys are strings
+            } else {
+                fileFocusIndex = currPane.fileFocusIndex
+            }
+            delete fileMultiFocusIndex[index]
+        } else { // Action is selection
+            fileMultiFocusIndex[index] = true
         }
 
         return {
@@ -87,7 +99,7 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,
-                    fileFocusIndex: index,
+                    fileFocusIndex,
                     fileMultiFocusIndex,
                 }, side)
             }
@@ -106,8 +118,6 @@ export default (state=initialState, action) => {
         for (let i = start; i <= end; i++) {
             fileMultiFocusIndex[i] = true
         }
-
-        console.log(start, end)
 
         return {
             ...state,

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -27,7 +27,7 @@ const INITIAL_PANE = {
     sortingColumn: 'name',
     sortingAsc: true,
     fileFocusIndex: 0,
-    fileMultiFocusIndex: {0: true},
+    fileMultiFocusIndexes: {0: true},
     history: [],
 }
 
@@ -67,7 +67,7 @@ export default (state=initialState, action) => {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
                     fileFocusIndex: index,
-                    fileMultiFocusIndex: {[index]: true},
+                    fileMultiFocusIndexes: {[index]: true},
                 }, side)
             }
         }
@@ -77,11 +77,11 @@ export default (state=initialState, action) => {
         const side = action.payload.side || getSide(state);
 
         const currPane = getCurrentPane(state, side)
-        const fileMultiFocusIndex = {...currPane.fileMultiFocusIndex}
+        const fileMultiFocusIndexes = {...currPane.fileMultiFocusIndexes}
         let fileFocusIndex = index
-        if (fileMultiFocusIndex[index]) { // Action is deselection
+        if (fileMultiFocusIndexes[index]) { // Action is deselection
             if (currPane.fileFocusIndex === index) { // The latest selected file
-                const keys = Object.keys(fileMultiFocusIndex).map(Number)
+                const keys = Object.keys(fileMultiFocusIndexes).map(Number)
                 if (keys.length <= 1) {
                     return state // At least one item should always be selected
                 }
@@ -89,9 +89,9 @@ export default (state=initialState, action) => {
             } else {
                 fileFocusIndex = currPane.fileFocusIndex
             }
-            delete fileMultiFocusIndex[index]
+            delete fileMultiFocusIndexes[index]
         } else { // Action is selection
-            fileMultiFocusIndex[index] = true
+            fileMultiFocusIndexes[index] = true
         }
 
         return {
@@ -100,7 +100,7 @@ export default (state=initialState, action) => {
                 ...setCurrentPane(state, {
                     ...currPane,
                     fileFocusIndex,
-                    fileMultiFocusIndex,
+                    fileMultiFocusIndexes,
                 }, side)
             }
         }
@@ -110,13 +110,13 @@ export default (state=initialState, action) => {
         const side = action.payload.side || getSide(state);
 
         const currPane = getCurrentPane(state, side)
-        const fileMultiFocusIndex = {
-            ...currPane.fileMultiFocusIndex,
+        const fileMultiFocusIndexes = {
+            ...currPane.fileMultiFocusIndexes,
         }
         const start = Math.min(currPane.fileFocusIndex, index)
         const end = Math.max(currPane.fileFocusIndex, index)
         for (let i = start; i <= end; i++) {
-            fileMultiFocusIndex[i] = true
+            fileMultiFocusIndexes[i] = true
         }
 
         return {
@@ -124,7 +124,7 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...currPane,
-                    fileMultiFocusIndex,
+                    fileMultiFocusIndexes,
                 }, side)
             }
         }

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -137,8 +137,8 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
-                    fileFocusIndex: initialState.fileFocusIndex,
-                    fileMultiFocusIndex: initialState.fileMultiFocusIndexes,
+                    fileFocusIndex: INITIAL_PANE.fileFocusIndex,
+                    fileMultiFocusIndexes: INITIAL_PANE.fileMultiFocusIndexes,
                     path,
                 }, side)
             },
@@ -171,8 +171,8 @@ export default (state=initialState, action) => {
             panes: {
                 ...setCurrentPane(state, {
                     ...getCurrentPane(state, side),
-                    fileFocusIndex: initialState.fileFocusIndex,
-                    fileMultiFocusIndex: initialState.fileMultiFocusIndexes,
+                    fileFocusIndex: INITIAL_PANE.fileFocusIndex,
+                    fileMultiFocusIndexes: INITIAL_PANE.fileMultiFocusIndexes,
                     path,
                     host,
                 }, side)

--- a/src/frontend/js/reducers/paneReducer.jsx
+++ b/src/frontend/js/reducers/paneReducer.jsx
@@ -96,6 +96,34 @@ export default (state=initialState, action) => {
             }
         }
     }
+    case pane.FILE_RANGE_FOCUS_INDEX: {
+        const index = action.payload.index;
+        const side = action.payload.side || getSide(state);
+        const focusPaneLeft = side === 'left';
+
+        const currPane = getCurrentPane(state, side)
+        const fileMultiFocusIndexes = {
+            ...currPane.fileMultiFocusIndexes,
+        }
+        const start = Math.min(currPane.fileFocusIndex, index)
+        const end = Math.max(currPane.fileFocusIndex, index)
+        for (let i = start; i <= end; i++) {
+            fileMultiFocusIndexes[i] = true
+        }
+
+        console.log(start, end)
+
+        return {
+            ...state,
+            focusPaneLeft,
+            panes: {
+                ...setCurrentPane(state, {
+                    ...currPane,
+                    fileMultiFocusIndexes,
+                }, side)
+            }
+        }
+    }
     case pane.DIRECTORY_CHANGE: {
         const { side, path } = action.payload;
 

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -9,7 +9,7 @@ class Pane extends React.Component {
     }
 
     render() {
-        console.log(this.props.pane.fileMultiFocusIndexes)
+        console.log(this.props.pane.fileMultiFocusIndex)
 
         const paneFiles = this.props.files.map((file, i) => (
             <PaneFile
@@ -20,7 +20,7 @@ class Pane extends React.Component {
                 useSiUnits={this.props.useSiUnits}
                 active={this.props.active && (
                     i === this.props.pane.fileFocusIndex ||
-                    this.props.pane.fileMultiFocusIndexes[i]
+                    this.props.pane.fileMultiFocusIndex[i]
                 )}
                 onMouseDown={(event) => this.onFileClick(event, this.props.side, i)}
                 onDoubleClick={() => this.onFileDoubleClick(this.props.side, i)}
@@ -43,7 +43,7 @@ class Pane extends React.Component {
         const isMultiSelection = event.metaKey || event.ctrlKey
 
         if (isMultiSelection) {
-            this.props.onMultiSelect(side, [index])
+            this.props.onMultiSelect(side, index)
         } else if (isRangeSelection) {
             this.props.onRangeSelect(side, index)
         } else {
@@ -70,14 +70,14 @@ Pane.defaultProps = {
     active: false,
     useSiUnits: false,
     onSelect: (side, index) => {},
-    onMultiSelect: (side, indexes) => {},
+    onMultiSelect: (side, index) => {},
     onRangeSelect: (side, index) => {},
 }
 
 import {connect} from 'react-redux';
 import {
     fileFocusIndex,
-    fileMultiFocusIndexes,
+    fileMultiFocusIndex,
     fileRangeFocusIndex,
     directoryChange,
 } from 'actions/paneActions.jsx';
@@ -88,7 +88,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onSelect: (side, index) => dispatch(fileFocusIndex(side, index)),
-    onMultiSelect: (side, indexes) => dispatch(fileMultiFocusIndexes(side, indexes)),
+    onMultiSelect: (side, index) => dispatch(fileMultiFocusIndex(side, index)),
     onRangeSelect: (side, index) => dispatch(fileRangeFocusIndex(side, index)),
     onDirectoryChange: (side, path) => dispatch(directoryChange(side, path)),
 });

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -17,8 +17,8 @@ class Pane extends React.Component {
                 size={file.size}
                 useSiUnits={this.props.useSiUnits}
                 active={this.props.active && i === this.props.pane.fileFocusIndex}
-                onMouseDown={() => this.props.onSelect(this.props.side, i)}
-                onDoubleClick={() => this.onEnter(this.props.side, i)}
+                onMouseDown={(event) => this.onFileClick(event, this.props.side, i)}
+                onDoubleClick={() => this.onFileDoubleClick(this.props.side, i)}
             />
         ))
 
@@ -33,7 +33,20 @@ class Pane extends React.Component {
 
     }
 
-    onEnter(side, index) {
+    onFileClick(event, side, index) {
+        const isRangeSelection = event.shiftKey
+        const isMultiSelection = event.metaKey || event.ctrlKey
+
+        if (isMultiSelection) {
+
+        } else if (isRangeSelection) {
+
+        } else {
+            this.props.onSelect(side, index)
+        }
+    }
+
+    onFileDoubleClick(side, index) {
         const currPath = this.props.pane.path;
         const directoryToEnter = this.props.files[index]
         if (directoryToEnter.type !== 'dir') {

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -45,7 +45,7 @@ class Pane extends React.Component {
         if (isMultiSelection) {
             this.props.onMultiSelect(side, [index])
         } else if (isRangeSelection) {
-
+            this.props.onRangeSelect(side, index)
         } else {
             this.props.onSelect(side, index)
         }
@@ -71,10 +71,16 @@ Pane.defaultProps = {
     useSiUnits: false,
     onSelect: (side, index) => {},
     onMultiSelect: (side, indexes) => {},
+    onRangeSelect: (side, index) => {},
 }
 
 import {connect} from 'react-redux';
-import {fileFocusIndex, fileMultiFocusIndexes, directoryChange} from 'actions/paneActions.jsx';
+import {
+    fileFocusIndex,
+    fileMultiFocusIndexes,
+    fileRangeFocusIndex,
+    directoryChange,
+} from 'actions/paneActions.jsx';
 
 const mapStateToProps = state => ({
     useSiUnits: state.settings.useSiUnits,
@@ -83,7 +89,8 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
     onSelect: (side, index) => dispatch(fileFocusIndex(side, index)),
     onMultiSelect: (side, indexes) => dispatch(fileMultiFocusIndexes(side, indexes)),
-    onDirectoryChange: (side, path) => dispatch(directoryChange(side, path))
+    onRangeSelect: (side, index) => dispatch(fileRangeFocusIndex(side, index)),
+    onDirectoryChange: (side, path) => dispatch(directoryChange(side, path)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Pane);

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -16,10 +16,7 @@ class Pane extends React.Component {
                 name={file.name}
                 size={file.size}
                 useSiUnits={this.props.useSiUnits}
-                active={this.props.active && (
-                    i === this.props.pane.fileFocusIndex ||
-                    this.props.pane.fileMultiFocusIndexes[i]
-                )}
+                active={this.props.active && this.props.pane.fileMultiFocusIndexes[i]}
                 onMouseDown={(event) => this.onFileClick(event, this.props.side, i)}
                 onDoubleClick={() => this.onFileDoubleClick(this.props.side, i)}
             />

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -18,7 +18,7 @@ class Pane extends React.Component {
                 useSiUnits={this.props.useSiUnits}
                 active={this.props.active && (
                     i === this.props.pane.fileFocusIndex ||
-                    this.props.pane.fileMultiFocusIndex[i]
+                    this.props.pane.fileMultiFocusIndexes[i]
                 )}
                 onMouseDown={(event) => this.onFileClick(event, this.props.side, i)}
                 onDoubleClick={() => this.onFileDoubleClick(this.props.side, i)}
@@ -75,7 +75,7 @@ Pane.defaultProps = {
 import {connect} from 'react-redux';
 import {
     fileFocusIndex,
-    fileMultiFocusIndex,
+    fileMultiFocusIndexes,
     fileRangeFocusIndex,
     directoryChange,
 } from 'actions/paneActions.jsx';
@@ -86,7 +86,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onSelect: (side, index) => dispatch(fileFocusIndex(side, index)),
-    onMultiSelect: (side, index) => dispatch(fileMultiFocusIndex(side, index)),
+    onMultiSelect: (side, index) => dispatch(fileMultiFocusIndexes(side, index)),
     onRangeSelect: (side, index) => dispatch(fileRangeFocusIndex(side, index)),
     onDirectoryChange: (side, path) => dispatch(directoryChange(side, path)),
 });

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -9,7 +9,7 @@ class Pane extends React.Component {
     }
 
     render() {
-        console.log(this.props.pane.fileSelectedIndexes)
+        console.log(this.props.pane.fileMultiFocusIndexes)
 
         const paneFiles = this.props.files.map((file, i) => (
             <PaneFile
@@ -20,7 +20,7 @@ class Pane extends React.Component {
                 useSiUnits={this.props.useSiUnits}
                 active={this.props.active && (
                     i === this.props.pane.fileFocusIndex ||
-                    this.props.pane.fileSelectedIndexes[i]
+                    this.props.pane.fileMultiFocusIndexes[i]
                 )}
                 onMouseDown={(event) => this.onFileClick(event, this.props.side, i)}
                 onDoubleClick={() => this.onFileDoubleClick(this.props.side, i)}
@@ -74,7 +74,7 @@ Pane.defaultProps = {
 }
 
 import {connect} from 'react-redux';
-import {fileFocusIndex, fileSelectIndexes, directoryChange} from 'actions/paneActions.jsx';
+import {fileFocusIndex, fileMultiFocusIndexes, directoryChange} from 'actions/paneActions.jsx';
 
 const mapStateToProps = state => ({
     useSiUnits: state.settings.useSiUnits,
@@ -82,7 +82,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onSelect: (side, index) => dispatch(fileFocusIndex(side, index)),
-    onMultiSelect: (side, indexes) => dispatch(fileSelectIndexes(side, indexes)),
+    onMultiSelect: (side, indexes) => dispatch(fileMultiFocusIndexes(side, indexes)),
     onDirectoryChange: (side, path) => dispatch(directoryChange(side, path))
 });
 

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -9,8 +9,6 @@ class Pane extends React.Component {
     }
 
     render() {
-        console.log(this.props.pane.fileMultiFocusIndex)
-
         const paneFiles = this.props.files.map((file, i) => (
             <PaneFile
                 key={i}

--- a/src/frontend/js/views/App/Pane/Pane.jsx
+++ b/src/frontend/js/views/App/Pane/Pane.jsx
@@ -9,6 +9,8 @@ class Pane extends React.Component {
     }
 
     render() {
+        console.log(this.props.pane.fileSelectedIndexes)
+
         const paneFiles = this.props.files.map((file, i) => (
             <PaneFile
                 key={i}
@@ -16,7 +18,10 @@ class Pane extends React.Component {
                 name={file.name}
                 size={file.size}
                 useSiUnits={this.props.useSiUnits}
-                active={this.props.active && i === this.props.pane.fileFocusIndex}
+                active={this.props.active && (
+                    i === this.props.pane.fileFocusIndex ||
+                    this.props.pane.fileSelectedIndexes[i]
+                )}
                 onMouseDown={(event) => this.onFileClick(event, this.props.side, i)}
                 onDoubleClick={() => this.onFileDoubleClick(this.props.side, i)}
             />
@@ -38,7 +43,7 @@ class Pane extends React.Component {
         const isMultiSelection = event.metaKey || event.ctrlKey
 
         if (isMultiSelection) {
-
+            this.props.onMultiSelect(side, [index])
         } else if (isRangeSelection) {
 
         } else {
@@ -65,10 +70,11 @@ Pane.defaultProps = {
     active: false,
     useSiUnits: false,
     onSelect: (side, index) => {},
+    onMultiSelect: (side, indexes) => {},
 }
 
 import {connect} from 'react-redux';
-import {fileFocusIndex, directoryChange} from 'actions/paneActions.jsx';
+import {fileFocusIndex, fileSelectIndexes, directoryChange} from 'actions/paneActions.jsx';
 
 const mapStateToProps = state => ({
     useSiUnits: state.settings.useSiUnits,
@@ -76,6 +82,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
     onSelect: (side, index) => dispatch(fileFocusIndex(side, index)),
+    onMultiSelect: (side, indexes) => dispatch(fileSelectIndexes(side, indexes)),
     onDirectoryChange: (side, path) => dispatch(directoryChange(side, path))
 });
 

--- a/src/frontend/js/views/App/Pane/PaneFile.jsx
+++ b/src/frontend/js/views/App/Pane/PaneFile.jsx
@@ -65,12 +65,4 @@ PaneFile.defaultProps = {
     onMouseDown: event => {},
 }
 
-import {connect} from 'react-redux';
-
-const mapStateToProps = state => ({
-});
-
-const mapDispatchToProps = dispatch => ({
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(PaneFile);
+export default PaneFile;

--- a/src/frontend/js/views/Dialogs/NewCopyJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewCopyJobDialog.jsx
@@ -26,57 +26,63 @@ class NewCopyJobDialog extends React.Component {
                         </Modal.Header>
                         <Modal.Body>
                             <div className="container">
-                                <h5 className="text-primary mb-2">Source</h5>
+                                {data.source_paths.map((sourcePath, i) => (
+                                    <React.Fragment key={sourcePath}>
+                                        <h5 className="text-primary mb-2">Source</h5>
 
-                                <div className="row">
-                                    <div className="col-4 text-right">
-                                        <b className='form-label'>Cloud</b>
-                                    </div>
-                                    <div className="col-7">
-                                        <span className="form-label">
-                                            {data['source_cloud'].name}
-                                        </span>
-                                    </div>
-                                    <div className="col-1"></div>
-                                </div>
-                                <div className="row">
-                                    <div className="col-4 text-right">
-                                        <b className='form-label'>Resource</b>
-                                    </div>
-                                    <div className="col-7">
-                                        <span className="form-label">
-                                            {data['src_resource_path']}
-                                        </span>
-                                    </div>
-                                    <div className="col-1"></div>
-                                </div>
+                                        <div className="row">
+                                            <div className="col-4 text-right">
+                                                <b className='form-label'>Cloud</b>
+                                            </div>
+                                            <div className="col-7">
+                                                <span className="form-label">
+                                                    {data['source_cloud'].name}
+                                                </span>
+                                            </div>
+                                            <div className="col-1"></div>
+                                        </div>
+                                        <div className="row">
+                                            <div className="col-4 text-right">
+                                                <b className='form-label'>Resource</b>
+                                            </div>
+                                            <div className="col-7">
+                                                <span className="form-label">
+                                                    {sourcePath}
+                                                </span>
+                                            </div>
+                                            <div className="col-1"></div>
+                                        </div>
 
-                                <h5 className="text-primary mt-5 mb-2">Destination</h5>
+                                        <h5 className="text-primary mt-4 mb-2">Destination</h5>
 
-                                <div className="row">
-                                    <div className="col-4 text-right">
-                                        <b className='form-label'>Cloud</b>
-                                    </div>
-                                    <div className="col-7">
-                                        <span className="form-label">
-                                            {data['destination_cloud'].name}
-                                        </span>
-                                    </div>
-                                    <div className="col-1"></div>
-                                </div>
-                                <div className="row">
-                                    <div className="col-4 text-right">
-                                        <b className='form-label'>Path</b>
-                                    </div>
-                                    <div className="col-7">
-                                        <span className="form-label">
-                                            {data['destination_path']}
-                                        </span>
-                                    </div>
-                                    <div className="col-1"></div>
-                                </div>
+                                        <div className="row">
+                                            <div className="col-4 text-right">
+                                                <b className='form-label'>Cloud</b>
+                                            </div>
+                                            <div className="col-7">
+                                                <span className="form-label">
+                                                    {data['destination_cloud'].name}
+                                                </span>
+                                            </div>
+                                            <div className="col-1"></div>
+                                        </div>
+                                        <div className="row">
+                                            <div className="col-4 text-right">
+                                                <b className='form-label'>Path</b>
+                                            </div>
+                                            <div className="col-7">
+                                                <span className="form-label">
+                                                    {data['destination_paths'][i]}
+                                                </span>
+                                            </div>
+                                            <div className="col-1"></div>
+                                        </div>
 
-                                <h5 className='text-primary mt-5 mb-2'>Details</h5>
+                                        <hr className='mt-4' />
+                                    </React.Fragment>
+                                ))}
+
+                                <h5 className='text-primary mb-2'>Details</h5>
 
                                 <div className="row form-group">
                                     <div className="col-4 text-right">
@@ -151,24 +157,27 @@ class NewCopyJobDialog extends React.Component {
         const propsData = this.props.data;
         const formData = serializeForm(event.target)
 
-        const data = {
-            "description": formData['description'] || '',
-            "copy_links": formData['copy_links'] || false,
-            "src_cloud_id": propsData['source_cloud'].id,
-            "src_resource_path": propsData['src_resource_path'],
-            "dst_cloud_id": propsData['destination_cloud'].id,
-            "dst_resource_path": propsData['destination_path'],
-            "owner": "owner", // TODO: Figure out why this was hard coded
-        }
+        for (let i in propsData.source_paths) {
+            const src_resource_path = propsData.source_paths[i]
+            const dst_resource_path = propsData.destination_paths[i]
+            const data = {
+                "description": formData['description'] || '',
+                "copy_links": formData['copy_links'] || false,
+                "src_cloud_id": propsData['source_cloud'].id,
+                "src_resource_path": src_resource_path,
+                "dst_cloud_id": propsData['destination_cloud'].id,
+                "dst_resource_path": dst_resource_path,
+            }
 
-        if (data['src_cloud_id'] === 0) {
-            delete data['src_cloud_id'];
-        }
-        if (data['dst_cloud_id'] === 0) {
-            delete data['dst_cloud_id'];
-        }
+            if (data['src_cloud_id'] === 0) {
+                delete data['src_cloud_id'];
+            }
+            if (data['dst_cloud_id'] === 0) {
+                delete data['dst_cloud_id'];
+            }
 
-        this.props.onSubmit(data);
+            this.props.onSubmit(data);
+        }
     }
 
     componentDidMount() {


### PR DESCRIPTION
Closes #82 

There is an interesting UX discussion in this article-like PR.

## Selection UX

Few new UX controls have been added to support multiple file selection:

- <kbd>cmd</kbd>+click (macOS) / <kbd>ctrl</kbd>+click (Linux, Windows) adds a new file to the selection
- <kbd>shift</kbd>+click adds a new range to the selection
- click - with no modifier - selects a single file and clears the selection

![Screen Shot 2019-12-22 at 13 03 29](https://user-images.githubusercontent.com/3248682/71327287-79d97480-24bb-11ea-9f1f-06f88e5e0c45.png)

## Transfer UX

The selection UX was relatively straight forward, because it largely follows the expectation contracts laid down by file managers such as Windows Explorer or macOS Finder. The Transfer UX decision, on the other hand is a bit more nuanced.

Let's look at the following scenario: the user selects folders A and C from left and copies them to the right

![Screen Shot 2019-12-22 at 13 09 21](https://user-images.githubusercontent.com/3248682/71327358-4a773780-24bc-11ea-8b9a-4894472d6b65.png)


There are two ways of implementing this:
- Implement each file / folder transfer as an individual request *(implemented)*
- Implement the entire transfer as a unit

The main difference lays in the number of "copy jobs" seen in the Copy Job table.

Let's discuss and compare the two

### Implement each file / folder transfer as an individual request

Pros:
- No backend changes are required at all. This PR comes as a pure UI change
- Simpler API. If we add multiple file copy support to the API, the API will have to inherit `rclone`'s confusing choice of `--include` flags. I personally found the flag quite odd when finding my way around it. Few reasons for that, from the top of my head: 
  - Folders and files are treated differently: folders are included as `folderName/**`, while files are included as `fileName`
  - The path has to be the Lowest Common Ancestor (LCA) of all files being transferred. This is easy to enforce in the UI, but become really difficult in the free-form version of the API
  - The `--include`s must be relative to the given path, otherwise they act as wildcard selectors (potential source of bugs)
- Besides the NewCopyJobDialog, which now shows a list of all files to be copied, the UI is unchanged.

Cons:
- Consumers of the API cannot take advantage of this feature, given it's UI only.
- One major disadvantage is that the UI refreshes at the end of each file transfer. This leads to a jarring experience until https://github.com/FredHutch/motuz/issues/96 is implemented.
- The transfers must be monitored separately now. If one of them fails, it must be investigated individually. Checksums have the same issue.
- There is no more one-to-one mapping between the dialog to create a new job and the dialog to view that job. This breaks potential features like: open the detail dialog for a job right after submitting the job, so the user does not have to manually open it from the CopyJobTable.

### Implement the entire transfer as a unit

Pros:
- Having the transfer be executed as one unit makes more sense from a user standpoint
- We can build on top of this to provide bulk verification for the entire transfer once https://github.com/FredHutch/motuz/issues/170 is implemented

Cons:
- This option is considerably harder to implement because it breaks many fundamental assumptions that have been made, which I will illustrate below
- Breakage in data modeling assumption. At the moment we have one source and one destination. If we have multiple sources and one destination in one copy job, this now needs database changes, migrations of old data, parsing of a variable-length field (sources), etc
- UI for the CopyJobTable (at the bottom) must be changed or thrown away. At the moment there is one column for source and one column for destination.
- UI for the details of a copy job must be changed. This is significantly easier to do than the change of CopyJobTable, but still it will require some creativity to make the dialog not look cluttered
- We need to start using the `--include` option on rclone. This increases the interaction surface between motuz and rclone, which can (possibly) lead to new bugs over the long run.
- The term "as a unit" is really misleading. In the `--include` version of `rclone`, if one small file finishes transferring before some slower files fail (for instance space exceeded), the small files are not in fact cleaned up and, basically, the system is now in a partially complete state. This is behavior is better reflected (i.e. less confusing) in the individual transfer version, where one fail means nothing was transferred, while one success means everything got transferred.


### Decision

While each option has its pros and cons, we decided to go for the former idea. Implementing that was 30 minutes chunk of work and will be easily reversible if needed. Implementing the other way would have been a multi-hour (or multi-day) investment that would be more difficult to revert.


