### PR TITLE
added full path to sudo rclone call due to user PATHs not including r…

### DIFF
--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -122,7 +122,7 @@ class HashsumJobQueue:
                     'sudo',
                     '-E',
                     '-u', user,
-                    'rclone',
+                    '/usr/local/bin/rclone',
                     'cat',
                     'src:{}'.format(os.path.join(os.path.dirname(base), file['Name'])),
                 ]

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -39,7 +39,7 @@ class RcloneConnection(AbstractConnection):
             'sudo',
             '-E',
             '-u', user,
-            'rclone',
+            '/usr/local/bin/rclone',
             'lsjson',
             'current:{}'.format(bucket),
         ]
@@ -68,7 +68,7 @@ class RcloneConnection(AbstractConnection):
             'sudo',
             '-E',
             '-u', user,
-            'rclone',
+            '/usr/local/bin/rclone',
             'lsjson',
             'current:{}'.format(path),
         ]
@@ -94,7 +94,7 @@ class RcloneConnection(AbstractConnection):
             'sudo',
             '-E',
             '-u', user,
-            'rclone',
+            '/usr/local/bin/rclone',
             'touch',
             'current:{}/.motuz_keep'.format(path),
         ]
@@ -143,7 +143,7 @@ class RcloneConnection(AbstractConnection):
             'sudo',
             '-E',
             '-u', user,
-            'rclone',
+            '/usr/local/bin/rclone',
             'copyto',
             src,
             dst,
@@ -203,7 +203,7 @@ class RcloneConnection(AbstractConnection):
             'sudo',
             '-E',
             '-u', user,
-            'rclone',
+            '/usr/local/bin/rclone',
             'md5sum',
             src,
         ]


### PR DESCRIPTION
call rclone with the full path in case user shell PATHs do not include /usr/local/bin as described in https://github.com/FredHutch/motuz/issues/252