### PR TITLE
Reduced size of docker images

### DIFF
--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -1,13 +1,14 @@
 # Build as
 # docker build -t fredhutch/motuz_app:latest -f deployment/docker/app/Dockerfile .
 
-FROM python:3.7.3
+FROM python:3.7.3-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN set -x \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends --no-install-suggests \
+        build-essential \
         curl \
         unzip \
         krb5-user \

--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -11,10 +11,11 @@ RUN apt-get install -y build-essential man-db vim curl unzip wget krb5-user libp
 
 # pin to a specific version of rclone.
 # if we decide to update, do it here:
-RUN curl -LO https://downloads.rclone.org/v1.47.0/rclone-v1.47.0-linux-amd64.zip
-RUN unzip rclone-v1.47.0-linux-amd64.zip
-RUN cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/
-RUN rm -rf rclone-v1.47.0-linux-amd64.zip rclone-v1.47.0-linux-amd64/
+RUN set -x \
+    && curl -LO https://downloads.rclone.org/v1.47.0/rclone-v1.47.0-linux-amd64.zip \
+    && unzip rclone-v1.47.0-linux-amd64.zip \
+    && cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/ \
+    && rm -rf rclone-v1.47.0-linux-amd64.zip rclone-v1.47.0-linux-amd64/
 
 ENV PYTHONUNBUFFERED 1
 ENV DOCKER_CONTAINER 1

--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -8,12 +8,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -x \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends --no-install-suggests \
-        build-essential \
-        man-db \
-        vim \
         curl \
         unzip \
-        wget \
         krb5-user \
         libpam-krb5 \
         sudo \

--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -1,7 +1,7 @@
 # Build as
 # docker build -t fredhutch/motuz_app:latest -f deployment/docker/app/Dockerfile .
 
-FROM python:3.7.3-slim
+FROM python:3.7.3-slim as build-image
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -9,11 +9,32 @@ RUN set -x \
     && apt-get update -y \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         build-essential \
-        curl \
-        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/root/.local/bin:$PATH
+COPY ./requirements.txt /code/requirements.txt
+RUN pip install --user -r /code/requirements.txt
+
+
+
+
+
+
+FROM python:3.7.3-slim
+
+COPY --from=build-image /root/.local /root/.local
+ENV PATH=/root/.local/bin:$PATH
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -x \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
         krb5-user \
         libpam-krb5 \
         sudo \
+        curl \
+        unzip \
     && curl -LO https://downloads.rclone.org/v1.47.0/rclone-v1.47.0-linux-amd64.zip \
     && unzip rclone-v1.47.0-linux-amd64.zip \
     && cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/ \
@@ -21,6 +42,7 @@ RUN set -x \
     && apt-get remove --purge --auto-remove -y \
         unzip \
         curl \
+    && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1
@@ -29,10 +51,6 @@ ENV FLASK_ENV development
 ENV MOTUZ_HOST 0.0.0.0
 # libpython3.7m.so.1.0 cannot be found if /etc is remapped
 ENV LD_LIBRARY_PATH /usr/local/lib
-
-
-COPY ./requirements.txt /code/requirements.txt
-RUN pip install -r /code/requirements.txt
 
 RUN set -x \
     && install -d -m 755 /root/.config/rclone/ \

--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN set -x \
     && apt-get update -y \
-    && apt-get install -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
         build-essential \
         man-db \
         vim \
@@ -20,7 +20,9 @@ RUN set -x \
     && curl -LO https://downloads.rclone.org/v1.47.0/rclone-v1.47.0-linux-amd64.zip \
     && unzip rclone-v1.47.0-linux-amd64.zip \
     && cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/ \
-    && rm -rf rclone-v1.47.0-linux-amd64.zip rclone-v1.47.0-linux-amd64/
+    && rm -rf rclone-v1.47.0-linux-amd64.zip rclone-v1.47.0-linux-amd64/ \
+    && apt-get remove --purge --auto-remove -y \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1
 ENV DOCKER_CONTAINER 1

--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -5,13 +5,18 @@ FROM python:3.7.3
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y
-
-RUN apt-get install -y build-essential man-db vim curl unzip wget krb5-user libpam-krb5 sudo
-
-# pin to a specific version of rclone.
-# if we decide to update, do it here:
 RUN set -x \
+    && apt-get update -y \
+    && apt-get install -y \
+        build-essential \
+        man-db \
+        vim \
+        curl \
+        unzip \
+        wget \
+        krb5-user \
+        libpam-krb5 \
+        sudo \
     && curl -LO https://downloads.rclone.org/v1.47.0/rclone-v1.47.0-linux-amd64.zip \
     && unzip rclone-v1.47.0-linux-amd64.zip \
     && cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/ \

--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -18,6 +18,8 @@ RUN set -x \
     && cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/ \
     && rm -rf rclone-v1.47.0-linux-amd64.zip rclone-v1.47.0-linux-amd64/ \
     && apt-get remove --purge --auto-remove -y \
+        unzip \
+        curl \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED 1
@@ -31,9 +33,9 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r /code/requirements.txt
 
-RUN mkdir -p /root/.config/rclone/
-RUN touch /root/.config/rclone/rclone.conf
-RUN chmod 755 /root
+RUN set -x \
+    && install -d -m 755 /root/.config/rclone/ \
+    && touch /root/.config/rclone/rclone.conf
 
 COPY ./src/backend /app/src/backend
 COPY \

--- a/deployment/docker/database_init/Dockerfile
+++ b/deployment/docker/database_init/Dockerfile
@@ -2,7 +2,7 @@
 # docker build --no-cache=true -t fredhutch/motuz_database_init:latest -f deployment/docker/database_init/Dockerfile .
 # docker run -it --rm -v /docker/volumes/postgres:/var/lib/postgresql/data fredhutch/motuz_database_init:latest
 
-FROM postgres:11.3
+FROM postgres:11.3-alpine
 
 COPY \
     ./deployment/docker/database_init/database_init-entrypoint.sh \

--- a/deployment/docker/nginx/Dockerfile
+++ b/deployment/docker/nginx/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t fredhutch/motuz_nginx:latest -f deployment/docker/nginx/Dockerfile .
 
 
-FROM node:10.15.2 as build-stage
+FROM node:10.15.2-alpine as build-stage
 
 WORKDIR /app
 COPY ./package.json /app
@@ -11,7 +11,7 @@ RUN npm install
 COPY ./src/frontend /app/src/frontend
 RUN npm run build
 
-FROM nginx
+FROM nginx:1.17.9-alpine
 
 COPY --from=build-stage /app/build/ /var/www/
 COPY ./deployment/docker/nginx/wsgi.params /etc/nginx/wsgi.params

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
 
     rabbitmq:
         container_name: motuz_rabbitmq
-        image: rabbitmq:3.7.16
+        image: rabbitmq:3.7.16-alpine
         network_mode: host
         ports:
             - 5672:5672
@@ -98,7 +98,7 @@ services:
 
     database:
         container_name: motuz_database
-        image: postgres:11.3
+        image: postgres:11.3-alpine
         network_mode: host
         volumes:
             - ${MOTUZ_DOCKER_ROOT:-/docker}/volumes/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
Closes #299 

Size reductions

| Image name | Size Before | Size After | 
| --- | --- | --- |
| motuz_app | 1.15 GB | 274 MB |
| motuz_celery | 1.15 GB | 274 MB |
| motuz_nginx | 128 MB | 20.7 MB |
| rabbitmq | 147 MB | 89.8 MB |
| database | 312 MB | 70.8 MB |


More details follow in the analysis below.