### PR TITLE
Allow spaces in group name in quickstart.sh

### DIFF
--- a/bin/quickstart.sh
+++ b/bin/quickstart.sh
@@ -69,7 +69,7 @@ create_folders() {
     if ! [ -d "${MOTUZ_DOCKER_ROOT}" ]; then
         _confirm "Create directory ${MOTUZ_DOCKER_ROOT} ?"
         set -x
-        sudo install -d -o $USER -g $(id -gn) -m 755 ${MOTUZ_DOCKER_ROOT}
+        sudo install -d -o $USER -g "$(id -gn)" -m 755 ${MOTUZ_DOCKER_ROOT}
         set +x
     else
         _color_yellow "${MOTUZ_DOCKER_ROOT} exists. Skipping..."


### PR DESCRIPTION
quickstart.sh would stop on error if your group name had a space in it.