### PR TITLE
proposed fix for #332

### DIFF
--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -147,6 +147,7 @@ class RcloneConnection(AbstractConnection):
             '-E',
             '-u', user,
             '/usr/local/bin/rclone',
+            '--exclude "\.snapshot/"',
             '--config=/dev/null',
             'copyto',
             src,

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -147,7 +147,8 @@ class RcloneConnection(AbstractConnection):
             '-E',
             '-u', user,
             '/usr/local/bin/rclone',
-            '--exclude "\.snapshot/"',
+            '--exclude "\.snapshot/"', # .snapshot directory contains lots of stuff
+                                       # and may never copy, see issue #332
             '--config=/dev/null',
             'copyto',
             src,


### PR DESCRIPTION
Will exclude `.snapshot` directories on copy. 
