### PR TITLE
Deleting identical hash trees in Hashsum Validations

### DIFF
--- a/src/backend/api/managers/hashsum_job_manager.py
+++ b/src/backend/api/managers/hashsum_job_manager.py
@@ -67,13 +67,10 @@ def retrieve(id):
     for _ in range(2): # Sometimes Rabbitmq closes the connection, just retry
         try:
             task = tasks.hashsum_job.AsyncResult(str(hashsum_job.id))
-            hashsum_job.progress_src_text = task.info.get('progress_src_text', '')
-            hashsum_job.progress_dst_text = task.info.get('progress_dst_text', '')
-            hashsum_job.progress_src_error_text = task.info.get('progress_src_error_text', '')
-            hashsum_job.progress_dst_error_text = task.info.get('progress_dst_error_text', '')
-
             hashsum_job.progress_src_tree = task.info.get('progress_src_tree', '')
             hashsum_job.progress_dst_tree = task.info.get('progress_dst_tree', '')
+            hashsum_job.progress_src_error_text = task.info.get('progress_src_error_text', '')
+            hashsum_job.progress_dst_error_text = task.info.get('progress_dst_error_text', '')
             break
         except Exception:
             pass

--- a/src/backend/api/managers/hashsum_job_manager.py
+++ b/src/backend/api/managers/hashsum_job_manager.py
@@ -71,6 +71,9 @@ def retrieve(id):
             hashsum_job.progress_dst_text = task.info.get('progress_dst_text', '')
             hashsum_job.progress_src_error_text = task.info.get('progress_src_error_text', '')
             hashsum_job.progress_dst_error_text = task.info.get('progress_dst_error_text', '')
+
+            hashsum_job.progress_src_tree = task.info.get('progress_src_tree', '')
+            hashsum_job.progress_dst_tree = task.info.get('progress_dst_tree', '')
             break
         except Exception:
             pass

--- a/src/backend/api/managers/hashsum_job_manager.py
+++ b/src/backend/api/managers/hashsum_job_manager.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from flask import request
@@ -67,8 +68,8 @@ def retrieve(id):
     for _ in range(2): # Sometimes Rabbitmq closes the connection, just retry
         try:
             task = tasks.hashsum_job.AsyncResult(str(hashsum_job.id))
-            hashsum_job.progress_src_tree = task.info.get('progress_src_tree', '')
-            hashsum_job.progress_dst_tree = task.info.get('progress_dst_tree', '')
+            hashsum_job.progress_src_tree = json.dumps(task.info.get('progress_src_tree', []))
+            hashsum_job.progress_dst_tree = json.dumps(task.info.get('progress_dst_tree', []))
             hashsum_job.progress_src_error_text = task.info.get('progress_src_error_text', '')
             hashsum_job.progress_dst_error_text = task.info.get('progress_dst_error_text', '')
             break

--- a/src/backend/api/managers/hashsum_job_manager.py
+++ b/src/backend/api/managers/hashsum_job_manager.py
@@ -71,7 +71,6 @@ def retrieve(id):
             hashsum_job.progress_dst_text = task.info.get('progress_dst_text', '')
             hashsum_job.progress_src_error_text = task.info.get('progress_src_error_text', '')
             hashsum_job.progress_dst_error_text = task.info.get('progress_dst_error_text', '')
-            hashsum_job.progress_error_text = task.info.get('progress_error_text', '')
             break
         except Exception:
             pass

--- a/src/backend/api/tasks/celery_tasks.py
+++ b/src/backend/api/tasks/celery_tasks.py
@@ -144,18 +144,9 @@ def hashsum_job(self, task_id):
         progress_src_tree = generate_file_tree(progress_src_text)
         progress_dst_tree = generate_file_tree(progress_dst_text)
 
-        print(progress_src_tree)
         progress_src_tree, progress_dst_tree = remove_identical_branches(progress_src_tree, progress_dst_tree)
-        print(progress_src_tree)
 
-        # progress_src_text, progress_dst_text = _removeIdenticalFiles(
-        #     progress_src_text,
-        #     progress_dst_text,
-        # )
         result = {
-            "progress_src_text": progress_src_text,
-            "progress_dst_text": progress_dst_text,
-
             "progress_src_tree": json.dumps(progress_src_tree),
             "progress_dst_tree": json.dumps(progress_dst_tree),
 
@@ -220,11 +211,6 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
     rclone_connection_id = f"{hashsum_job.id}_{side}"
     connection = RcloneConnection()
 
-    def get_hashsum_text():
-        # Using closure to capture all parameters
-        files = connection.hashsum_text(rclone_connection_id)
-        return files
-
     def get_hashsum_tree():
         # Using closure to capture all parameters
         files = connection.hashsum_text(rclone_connection_id)
@@ -249,7 +235,6 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
         db.session.commit()
 
         self.update_state(state='PROGRESS', meta={
-            f'progress_{side}_text': get_hashsum_text(),
             f'progress_{side}_tree': get_hashsum_tree(),
             f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
         })
@@ -265,7 +250,6 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
         return {
             "success": False,
             "payload": {
-                f'progress_{side}_text': get_hashsum_text(),
                 f'progress_{side}_tree': get_hashsum_tree(),
                 f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
             },
@@ -276,7 +260,6 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
         return {
             "success": False,
             "payload": {
-                f'progress_{side}_text': get_hashsum_text(),
                 f'progress_{side}_tree': get_hashsum_tree(),
                 f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
             },
@@ -285,7 +268,6 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
     return {
         "success": True,
         "payload": {
-            f'progress_{side}_text': get_hashsum_text(),
             f'progress_{side}_tree': get_hashsum_tree(),
             f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
         }

--- a/src/backend/api/tasks/celery_tasks.py
+++ b/src/backend/api/tasks/celery_tasks.py
@@ -1,5 +1,4 @@
 import functools
-import json
 import logging
 from os import path as os_path
 import re
@@ -108,9 +107,9 @@ def copy_job(self, task_id=None):
 def hashsum_job(self, task_id):
     """
     @return : dict {
-        "progress_src_text",
+        "progress_src_tree",
         "progress_src_error_text",
-        "progress_dst_text",
+        "progress_dst_tree",
         "progress_dst_error_text",
     }
     """
@@ -212,8 +211,7 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
         # Using closure to capture all parameters
         files = connection.hashsum_text(rclone_connection_id)
         tree = generate_file_tree(files)
-        output = tree
-        return output
+        return tree
 
     result = connection.md5sum(
         data=getattr(hashsum_job, f'{side}_cloud'),

--- a/src/backend/api/tasks/celery_tasks.py
+++ b/src/backend/api/tasks/celery_tasks.py
@@ -238,13 +238,15 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
 
         time.sleep(1)
 
+    result = {}
+
     exitstatus = connection.hashsum_exitstatus(rclone_connection_id)
     if exitstatus == -1:
         logging.error("Hashsum Job did not set its status")
 
         hashsum_job.progress_state = 'UNSET'
         hashsum_job.progress_current = 100
-        return {
+        result = {
             "success": False,
             "payload": {
                 f'progress_{side}_tree': get_hashsum_tree(),
@@ -254,18 +256,21 @@ def _hashsum_job_single(self, hashsum_job, *, start_time, side):
     elif exitstatus != 0:
         hashsum_job.progress_state = 'FAILED'
         hashsum_job.progress_current = 100
-        return {
+        result = {
             "success": False,
             "payload": {
                 f'progress_{side}_tree': get_hashsum_tree(),
                 f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
             },
         }
-
-    return {
-        "success": True,
-        "payload": {
-            f'progress_{side}_tree': get_hashsum_tree(),
-            f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
+    else:
+        result = {
+            "success": True,
+            "payload": {
+                f'progress_{side}_tree': get_hashsum_tree(),
+                f'progress_{side}_error_text': connection.hashsum_error_text(rclone_connection_id)
+            }
         }
-    }
+
+    connection.hashsum_delete(rclone_connection_id)
+    return result

--- a/src/backend/api/utils/file_utils.py
+++ b/src/backend/api/utils/file_utils.py
@@ -1,0 +1,133 @@
+import logging
+
+def generate_file_tree(data):
+    """
+    Trees are of the form
+    [
+        { title: 'user1', children: [
+            { title: 'file1.txt', hash: 'd621730bdf867a3453fb6b51a4ba0faa', type: 'modify' },
+
+
+    @param data list(dict({
+        Name,
+        md5chksum,
+    }))
+
+    @return list(dict({
+        title : str,
+        children : list,
+        hash: str,
+    }))
+    """
+
+    data.sort(key=lambda d: d["Name"])
+
+    tree = []
+    try:
+        for item in data:
+            # TODO: Figure out why there is a need for checking for none
+            parts = item["Name"].split('/') if item is not None and item["Name"] is not None else []
+            _generate_tree_leaf(tree, parts, item["md5chksum"])
+    except Exception as e:
+        logging.exception(e)
+
+    return tree
+
+
+def _generate_tree_leaf(branches, parts, md5chksum):
+    """
+    Recursive function that generates a tree leaf from parts
+
+    @param branches: list(dict({
+        title,
+        children,
+        hash,
+    }))
+    @param parts: list(str)
+    @param md5chksum: str
+    """
+
+    for i, part in enumerate(parts):
+        try:
+            # TODO: optimize
+            branch = next(branch for branch in branches if branch["title"] == part)
+        except StopIteration:
+            branch = {"title": part, "children": []}
+            branches.append(branch)
+
+        if i == len(parts) - 1:
+            branch["hash"] = md5chksum
+            branch["isLeaf"] = True
+            del branch["children"]
+        else:
+            branches = branch["children"]
+
+
+
+def remove_identical_branches(left, right):
+    """
+    @param left list(dict({
+        title,
+        children,
+        hash
+    }))
+    @param right list(dict({
+        title,
+        children,
+        hash
+    }))
+
+    @return new_left
+    @return new_right
+    """
+
+    new_left = []
+    new_right = []
+
+    i = 0
+    j = 0
+
+    while i < len(left) and j < len(right):
+        a = left[i]
+        b = right[j]
+
+        if a["title"] < b["title"]:
+            new_left.append(a)
+            i += 1
+        elif a["title"] > b["title"]:
+            new_right.append(b)
+            j += 1
+        else: # a["title"] == b["title"]
+            if a.get("children") is not None and b.get("children") is not None: # Both folders
+                a_children, b_children = remove_identical_branches(a["children"], b["children"])
+                if not (len(a_children) == 0 and len(b_children) == 0):
+                    # Append path if at least one side still has a diff
+                    new_a = {
+                        **a,
+                        "children": a_children
+                    }
+                    new_b = {
+                        **b,
+                        "children": b_children
+                    }
+                    new_left.append(new_a)
+                    new_right.append(new_b)
+            elif a.get("hash") is not None and b.get("hash") is not None: # Both files
+                if a["hash"] != b["hash"]:
+                    new_left.append(a)
+                    new_right.append(b)
+            else: # One is file, other is folder
+                new_left.append(a)
+                new_right.append(b)
+
+            i += 1
+            j += 1
+
+    while i < len(left):
+        new_left.append(left[i])
+        i += 1
+
+    while j < len(right):
+        new_right.append(right[j])
+
+    return new_left, new_right

--- a/src/backend/api/utils/file_utils.py
+++ b/src/backend/api/utils/file_utils.py
@@ -16,7 +16,8 @@ def generate_file_tree(data):
     @return list(dict({
         title : str,
         children : list,
-        hash: str,
+        hash : str,
+        isLeaf : bool,
     }))
     """
 
@@ -42,6 +43,7 @@ def _generate_tree_leaf(branches, parts, md5chksum):
         title,
         children,
         hash,
+        isLeaf,
     }))
     @param parts: list(str)
     @param md5chksum: str
@@ -69,12 +71,14 @@ def remove_identical_branches(left, right):
     @param left list(dict({
         title,
         children,
-        hash
+        hash,
+        isLeaf,
     }))
     @param right list(dict({
         title,
         children,
-        hash
+        hash,
+        isLeaf,
     }))
 
     @return new_left

--- a/src/backend/api/utils/file_utils_test.py
+++ b/src/backend/api/utils/file_utils_test.py
@@ -1,0 +1,63 @@
+import unittest
+
+from file_utils import remove_identical_branches
+
+class TestRemoveIdenticalBranches(unittest.TestCase):
+    def test_does_not_crash(self):
+        a, b = remove_identical_branches([], [])
+        self.assertEqual(len(a), 0)
+        self.assertEqual(len(b), 0)
+
+    def test_remove_is_correct(self):
+        left = [
+            {"title": "1", "hash": "123"},
+            {"title": "2", "hash": "456"},
+            {"title": "3", "hash": "789"},
+        ]
+        right = [
+            {"title": "1", "hash": "123"},
+            {"title": "2", "hash": "xxx"},
+            {"title": "3", "hash": "789"},
+        ]
+
+        a, b = remove_identical_branches(left, right)
+        self.assertEqual(len(a), 1)
+        self.assertEqual(a[0]["title"], "2")
+        self.assertEqual(a[0]["hash"], "456")
+        self.assertEqual(len(b), 1)
+        self.assertEqual(b[0]["title"], "2")
+        self.assertEqual(b[0]["hash"], "xxx")
+
+    def test_real_world(self):
+        left = [
+            {
+                "title": "bazz", "children": [
+                    {"title": "1.txt", "hash": "b026324c6904b2a9cb4b88d6d61c81d1"},
+                    {"title": "original.tx", "hash": "d41d8cd98f00b204e9800998ecf8427e"}
+                ]
+            }, {
+                "title": "foo", "children": [{
+                    "title": "2.txt", "hash": "d41d8cd98f00b204e9800998ecf8427e"}
+                ]
+            }
+        ]
+        right = [
+            {
+                "title": "bazz", "children": [{
+                    "title": "original.tx", "hash": "d41d8cd98f00b204e9800998ecf8427e"}
+            ]}, {
+                "title": "foo", "children": [
+                    {"title": "1.txt", "hash": "b026324c6904b2a9cb4b88d6d61c81d1"},
+                    {"title": "2.txt", "hash": "d41d8cd98f00b204e9800998ecf8427e"}
+                ]
+            }
+        ]
+
+        a, b = remove_identical_branches(left, right)
+        from pprint import pprint as pp
+        pp(a)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -105,6 +105,8 @@ class HashsumJobQueue:
                 'Name': groups[2],
                 'md5chksum': groups[1].strip() or None,
             })
+            import time
+            time.sleep(1)
             self.__process_copy_status(job_id)
 
 

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -105,8 +105,8 @@ class HashsumJobQueue:
                 'Name': groups[2],
                 'md5chksum': groups[1].strip() or None,
             })
-            import time
-            time.sleep(1)
+            # import time
+            # time.sleep(1)
             self.__process_copy_status(job_id)
 
 

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -108,8 +108,6 @@ class HashsumJobQueue:
                 'Name': groups[2],
                 'md5chksum': groups[1].strip() or None,
             })
-            # import time
-            # time.sleep(1)
             self.__process_copy_status(job_id)
 
 

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -54,6 +54,9 @@ class HashsumJobQueue:
     def hashsum_exitstatus(self, job_id):
         return self._job_exitstatus.get(job_id, -1)
 
+    def hashsum_delete(self, job_id):
+        self.hashsum_stop(job_id)
+        del self._job_status[job_id]
 
 
     def _job_id_exists(self, job_id):

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -241,6 +241,9 @@ class RcloneConnection(AbstractConnection):
     def hashsum_exitstatus(self, job_id):
         return self._hashsum_job_queue.hashsum_exitstatus(job_id)
 
+    def hashsum_delete(self, job_id):
+        return self._hashsum_job_queue.hashsum_delete(job_id)
+
 
     def _logCommand(self, command, credentials):
         bash_command = "{} {}".format(

--- a/src/backend/api/views/hashsum_job_views.py
+++ b/src/backend/api/views/hashsum_job_views.py
@@ -31,6 +31,8 @@ dto = api.model('hashsum-job', {
     'progress_total': fields.Integer(readonly=True, example=100),
     'progress_error': fields.String(readonly=True),
     'progress_execution_time': fields.Integer(readonly=True, example=3600),
+
+    # Rabbitmq fields
     'progress_src_text': fields.List(fields.Nested(job_output), readonly=True),
     'progress_src_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
     'progress_dst_text': fields.List(fields.Nested(job_output), readonly=True),

--- a/src/backend/api/views/hashsum_job_views.py
+++ b/src/backend/api/views/hashsum_job_views.py
@@ -38,13 +38,10 @@ dto = api.model('hashsum-job', {
     'progress_execution_time': fields.Integer(readonly=True, example=3600),
 
     # Rabbitmq fields
-    'progress_src_text': fields.List(fields.Nested(job_output), readonly=True),
-    'progress_src_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
-    'progress_dst_text': fields.List(fields.Nested(job_output), readonly=True),
-    'progress_dst_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
-
     'progress_src_tree': fields.String(readonly=True, example='[{title, children}]'),
+    'progress_src_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
     'progress_dst_tree': fields.String(readonly=True, example='[{title, children}]'),
+    'progress_dst_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
 })
 
 

--- a/src/backend/api/views/hashsum_job_views.py
+++ b/src/backend/api/views/hashsum_job_views.py
@@ -16,6 +16,11 @@ job_output = api.model('hashsum-job-output', {
     'md5chksum': fields.String(example='cea965d0c05b29b2adc970a79d408b67'),
 })
 
+new_job_output = api.model('hashsum-job-output', {
+    'title': fields.String(example='folder_name'),
+    'children': fields.String(example='job_output_recursion'),
+})
+
 dto = api.model('hashsum-job', {
     'id': fields.String(readonly=True, example='a6cac16a63d05672555c884d38b8a3'),
     'src_cloud_id': fields.Integer(required=False, example=1),
@@ -37,6 +42,9 @@ dto = api.model('hashsum-job', {
     'progress_src_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
     'progress_dst_text': fields.List(fields.Nested(job_output), readonly=True),
     'progress_dst_error_text': fields.String(readonly=True, example='Multi\nLine\nText'),
+
+    'progress_src_tree': fields.String(readonly=True, example='[{title, children}]'),
+    'progress_dst_tree': fields.String(readonly=True, example='[{title, children}]'),
 })
 
 

--- a/src/backend/api/views/hashsum_job_views.py
+++ b/src/backend/api/views/hashsum_job_views.py
@@ -11,16 +11,6 @@ from ..exceptions import HTTP_EXCEPTION
 
 api = Namespace('hashsum-jobs', description='CheckJob related operations')
 
-job_output = api.model('hashsum-job-output', {
-    'Name': fields.String(example='docker-compose.yml'),
-    'md5chksum': fields.String(example='cea965d0c05b29b2adc970a79d408b67'),
-})
-
-new_job_output = api.model('hashsum-job-output', {
-    'title': fields.String(example='folder_name'),
-    'children': fields.String(example='job_output_recursion'),
-})
-
 dto = api.model('hashsum-job', {
     'id': fields.String(readonly=True, example='a6cac16a63d05672555c884d38b8a3'),
     'src_cloud_id': fields.Integer(required=False, example=1),

--- a/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
@@ -17,6 +17,7 @@ class EditHashsumJobDialog extends React.Component {
 
     render() {
         const { data } = this.props;
+        const isInProgress = data.progress_state === 'PROGRESS'
 
         const cloudMapping = {
             0: {
@@ -46,10 +47,16 @@ class EditHashsumJobDialog extends React.Component {
             data.dst_cloud_type = dst_cloud.type;
         }
 
-        const left = data.progress_src_text || [];
-        const right = data.progress_dst_text || [];
+        const left = data.progress_src_tree || '[]';
+        const right = data.progress_dst_tree || '[]';
 
-        let {treeLeft, treeRight, diff} = this._processData(left, right)
+        const treeLeft = JSON.parse(left)
+        const treeRight = JSON.parse(right)
+
+        let diff = NodeType.LOADING
+        if (!isInProgress) {
+            diff = this._compareTrees(treeLeft, treeRight)
+        }
 
         if (!data.progress_src_text || !data.progress_dst_text) {
             diff = NodeType.LOADING
@@ -61,12 +68,10 @@ class EditHashsumJobDialog extends React.Component {
 
         let statusText = '';
         let statusColor = 'default';
-        let isInProgress = false;
 
         if (data.progress_state === 'PROGRESS') {
             statusText = data.progress_state;
             statusColor = 'primary';
-            isInProgress = true;
         } else if (data.progress_state === 'FAILED' || data.progress_state === 'STOPPED') {
             statusText = data.progress_state;
             statusColor = 'danger';
@@ -93,10 +98,11 @@ class EditHashsumJobDialog extends React.Component {
                 >
                     <form action="#">
                         <Modal.Header closeButton>
-                        <Modal.Title>
-                            <span>Integrity Check #{data.id} - </span>
-                            <b className={`text-${statusColor}`}>{statusText}</b>
-                        </Modal.Title>
+                            <Modal.Title>
+                                <span>Integrity Check #{data.id}</span>
+                                <span> - </span>
+                                <b className={`text-${statusColor}`}>{statusText}</b>
+                            </Modal.Title>
                         </Modal.Header>
                         <Modal.Body>
                             <div className="container">
@@ -119,7 +125,6 @@ class EditHashsumJobDialog extends React.Component {
                                             path={data.src_resource_path}
                                         />
                                     </div>
-
                                     <div className="col-6 overflow-hidden text-center">
                                         <UriResource
                                             protocol={data.dst_cloud_type}
@@ -194,6 +199,15 @@ class EditHashsumJobDialog extends React.Component {
                                         </i>
                                     </div>
                                 </div>
+                                {!isInProgress && (
+                                    <div className="row">
+                                        <div className="col-12">
+                                            <i>
+                                                <b>*** Showing only the difference</b>
+                                            </i>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         </Modal.Body>
                         <Modal.Footer>
@@ -260,56 +274,6 @@ class EditHashsumJobDialog extends React.Component {
         }
     }
 
-    _processData(left, right) {
-        left.sort((a, b) => sortComparator(a.Name, b.Name))
-        right.sort((a, b) => sortComparator(a.Name, b.Name))
-
-        const treeLeft = this._generateTree(left)
-        const treeRight = this._generateTree(right)
-        const diff = this._compareTrees(treeLeft, treeRight)
-
-        return {
-            treeLeft,
-            treeRight,
-            diff,
-        }
-    }
-
-    /**
-     * Trees are of the form
-     * [
-     *     { title: 'user1', children: [
-     *         { title: 'file1.txt', hash: 'd621730bdf867a3453fb6b51a4ba0faa', type: 'modify' },
-     *     },
-     * ]
-     */
-    _generateTree(data) {
-        const tree = []
-        for (let entry of data) {
-            // TODO: Figure out why this is sometimes failing
-            const parts = entry && entry.Name ? entry.Name.split('/') : []
-            this._generateTreeLeaf(tree, parts, entry.md5chksum)
-        }
-        return tree;
-    }
-
-    _generateTreeLeaf(branches, parts, md5chksum) {
-        for (let i = 0; i < parts.length; i++) {
-            const part = parts[i];
-            let branch = branches.find(d => d.title === part)
-            if (!branch) {
-                branch = {title: part, children: []}
-                branches.push(branch)
-            }
-            if (i === parts.length - 1) {
-                branch.hash = md5chksum
-                delete branch.children
-            } else {
-                branches = branch.children
-            }
-        }
-    }
-
     _compareTrees(treeLeft, treeRight) {
         treeLeft = treeLeft || []
         treeRight = treeRight || []
@@ -333,7 +297,7 @@ class EditHashsumJobDialog extends React.Component {
                 } else if (this._isLeaf(treeLeft[i]) || this._isLeaf(treeRight[j])) {
                     treeLeft[i].type = treeRight[j].type = 'modify';
                     diff = Math.max(diff, NodeType.MODIFY)
-                } else {
+                } else { // Both non leafs
                     const subtreeDiff = this._compareTrees(treeLeft[i].children, treeRight[j].children)
                     if (subtreeDiff === NodeType.MODIFY) {
                         treeLeft[i].type = treeRight[j].type = 'modify';
@@ -358,20 +322,20 @@ class EditHashsumJobDialog extends React.Component {
             treeLeft[i].type = 'insert'
             treeRight.splice(i, 0, {type: 'hidden'})
             diff = Math.max(diff, NodeType.MODIFY)
-            i++;
+            i++; j++;
         }
 
         while (j < treeRight.length) {
             treeRight[j].type = 'insert'
             treeLeft.splice(j, 0, {type: 'hidden'})
             diff = Math.max(diff, NodeType.MODIFY)
-            j++;
+            i++; j++;
         }
         return diff;
     }
 
     _isLeaf(treeNode) {
-        return !treeNode.children || !treeNode.children.length
+        return treeNode.isLeaf
     }
 
     _scheduleRefresh() {

--- a/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
@@ -56,7 +56,6 @@ class EditHashsumJobDialog extends React.Component {
         }
 
         const description = data.description ? ` - ${data.description}` : ''
-        const progressErrorText = data.progress_error_text;
         const progress = Math.floor(data.progress_current / data.progress_total * 100);
         const executionTime = parseTime(data.progress_execution_time);
 

--- a/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
@@ -109,8 +109,7 @@ class EditHashsumJobDialog extends React.Component {
                     <form action="#">
                         <Modal.Header closeButton>
                             <Modal.Title>
-                                <span>Integrity Check #{data.id}</span>
-                                <span> - </span>
+                                <span>Integrity Check #{data.id} - </span>
                                 <b className={`text-${statusColor}`}>{statusText}</b>
                             </Modal.Title>
                         </Modal.Header>

--- a/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/EditHashsumJobDialog.jsx
@@ -47,18 +47,28 @@ class EditHashsumJobDialog extends React.Component {
             data.dst_cloud_type = dst_cloud.type;
         }
 
-        const left = data.progress_src_tree || '[]';
-        const right = data.progress_dst_tree || '[]';
+        let treeLeft;
+        try {
+            treeLeft = JSON.parse(data.progress_src_tree || '[]')
+        } catch (e) {
+            console.error(e, data.progress_src_tree)
+            treeLeft = []
+        }
 
-        const treeLeft = JSON.parse(left)
-        const treeRight = JSON.parse(right)
+        let treeRight;
+        try {
+            treeRight = JSON.parse(data.progress_dst_tree || '[]')
+        } catch (e) {
+            console.error(e, data.progress_dst_tree)
+            treeRight = []
+        }
 
         let diff = NodeType.LOADING
         if (!isInProgress) {
             diff = this._compareTrees(treeLeft, treeRight)
         }
 
-        if (!data.progress_src_text || !data.progress_dst_text) {
+        if (!data.progress_src_tree || !data.progress_dst_tree) {
             diff = NodeType.LOADING
         }
 


### PR DESCRIPTION
Candidate for https://github.com/FredHutch/motuz/issues/330

At the moment, we are storing all the md5sum hashes of a Hashsum job inside Celery and we never clean it up. This is causing memory pressure and is, in turn, filling up the disk with 22MB files written once a second.

Each of the 22MB files has the checksums for 150,000 files.

```bash
$ strings 9999.rdq | grep -o md5chksum | wc
  147950  147950 1479500
```

This change cleans up the memory by deleting all the hashes that are identical between the files.

This was not trivial in the current design decisions, so a bit of refactoring was necessary.
