### PR TITLE
Added Frontend logic to avoid duplicate copy and hashsum jobs

### DIFF
--- a/src/frontend/js/actions/apiActions.jsx
+++ b/src/frontend/js/actions/apiActions.jsx
@@ -5,6 +5,7 @@ import { withAuth } from 'reducers/reducers.jsx';
 import * as pane from 'actions/paneActions.jsx'
 import * as dialog from 'actions/dialogActions.jsx'
 import { getCurrentPane, getCurrentFiles, fileExists } from 'managers/paneManager.jsx'
+import { getJobsInProgressForDestination } from 'managers/apiManager.jsx'
 
 export const LIST_FILES_REQUEST = '@@api/LIST_FILES_REQUEST';
 export const LIST_FILES_SUCCESS = '@@api/LIST_FILES_SUCCESS';
@@ -175,6 +176,16 @@ export const createCopyJob = (data) => {
             `${basename} already exists at destination. Overwrite?`
         )) {
             return;
+        }
+        const jobsInProgress = getJobsInProgressForDestination(state.api, data);
+        if (jobsInProgress.length !== 0) {
+            const jobIds = jobsInProgress.map(d => d.id).join(',')
+            if (!confirm(
+                `The following jobs already write to the same destination: ${jobIds}. ` +
+                `Concurrent writes may be destructive. Continue?`
+            )) {
+                return;
+            }
         }
         dispatch(_createCopyJob(data));
         await dispatch(dialog.hideNewCopyJobDialog())

--- a/src/frontend/js/actions/apiActions.jsx
+++ b/src/frontend/js/actions/apiActions.jsx
@@ -187,7 +187,7 @@ export const createCopyJob = (data) => {
                 return;
             }
         }
-        dispatch(_createCopyJob(data));
+        await dispatch(_createCopyJob(data));
         await dispatch(dialog.hideNewCopyJobDialog())
     }
 }
@@ -233,8 +233,8 @@ export const retrieveHashsumJob = (id) => ({
 
 export const createHashsumJob = (data) => {
     return async (dispatch, getState) => {
-        dispatch(_createHashsumJob(data));
-        await dispatch(dialog.hideNewHashsumJobDialog)
+        await dispatch(_createHashsumJob(data));
+        await dispatch(dialog.hideNewHashsumJobDialog())
     }
 }
 

--- a/src/frontend/js/managers/apiManager.jsx
+++ b/src/frontend/js/managers/apiManager.jsx
@@ -1,0 +1,18 @@
+/**
+ * Returns an array of jobs that are currently in progress and write to `dst`.
+ * Returns an empty array if no such jobs exist.
+ *
+ * @param data: dict{
+ *   id: int
+ *   dst_cloud_id: int
+ *   dst_resource_path: str
+ * }
+ */
+export function getJobsInProgressForDestination(state, data) {
+    const {dst_cloud_id, dst_resource_path} = data
+    return state.jobs.filter(d => (
+        d.progress_state === "PROGRESS" &&
+        d.dst_cloud_id === dst_cloud_id &&
+        d.dst_resource_path === dst_resource_path
+    ))
+}

--- a/src/frontend/js/reducers/loadersReducer.jsx
+++ b/src/frontend/js/reducers/loadersReducer.jsx
@@ -1,0 +1,30 @@
+import * as api from 'actions/apiActions.jsx';
+
+const initialState = {
+    createCopyJobLoading: false,
+    createHashsumJobLoading: false,
+};
+
+export default (state=initialState, action) => {
+    switch(action.type) {
+
+    case api.CREATE_COPY_JOB_REQUEST: {
+        return {...state, createCopyJobLoading: true };
+    }
+    case api.CREATE_COPY_JOB_SUCCESS:
+    case api.CREATE_COPY_JOB_FAILURE: {
+        return {...state, createCopyJobLoading: false };
+    }
+
+    case api.CREATE_HASHSUM_JOB_REQUEST: {
+        return {...state, createHashsumJobLoading: true };
+    }
+    case api.CREATE_HASHSUM_JOB_SUCCESS:
+    case api.CREATE_HASHSUM_JOB_FAILURE: {
+        return {...state, createHashsumJobLoading: false };
+    }
+
+    default:
+        return state;
+    }
+};

--- a/src/frontend/js/reducers/reducers.jsx
+++ b/src/frontend/js/reducers/reducers.jsx
@@ -6,6 +6,7 @@ import apiReducer from 'reducers/apiReducer.jsx'
 import dialogReducer from 'reducers/dialogReducer.jsx'
 import paneReducer from 'reducers/paneReducer.jsx'
 import settingsReducer from 'reducers/settingsReducer.jsx'
+import loadersReducer from 'reducers/loadersReducer.jsx'
 
 export default (history) => combineReducers({
     alert: alertReducer,
@@ -14,8 +15,8 @@ export default (history) => combineReducers({
     dialog: dialogReducer,
     pane: paneReducer,
     settings: settingsReducer,
+    loaders: loadersReducer,
 });
-
 
 
 export function withAuth(headers={}) {

--- a/src/frontend/js/views/Dialogs/NewCopyJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewCopyJobDialog.jsx
@@ -14,7 +14,7 @@ class NewCopyJobDialog extends React.Component {
     }
 
     render() {
-        const { data } = this.props;
+        const { data, isLoading } = this.props;
 
         return (
             <div className='dialog-copy-job'>
@@ -172,8 +172,8 @@ class NewCopyJobDialog extends React.Component {
                             <Button variant="secondary" onClick={() => this.handleClose()}>
                                 Cancel
                             </Button>
-                            <Button variant="primary" type='submit'>
-                                Submit Copy Job
+                            <Button variant="primary" type='submit' disabled={isLoading}>
+                                { isLoading ? "Submitting..." : "Submit Copy Job" }
                             </Button>
                         </Modal.Footer>
                     </form>
@@ -225,6 +225,8 @@ NewCopyJobDialog.defaultProps = {
     data: {},
     username: 'ERROR',
 
+    isLoading: false,
+
     followSymlinksDefault: false,
     emailNotificationsDefault: false,
     emailAddressDefault: "",
@@ -241,6 +243,8 @@ import { getCurrentUser } from 'reducers/authReducer.jsx';
 const mapStateToProps = state => ({
     data: state.dialog.newCopyJobDialogData,
     username: getCurrentUser(state.auth),
+
+    isLoading: state.loaders.createCopyJobLoading,
 
     followSymlinksDefault: state.settings.followSymlinks,
     emailNotificationsDefault: state.settings.emailNotifications,

--- a/src/frontend/js/views/Dialogs/NewCopyJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewCopyJobDialog.jsx
@@ -170,7 +170,7 @@ class NewCopyJobDialog extends React.Component {
                         </Modal.Body>
                         <Modal.Footer>
                             <Button variant="secondary" onClick={() => this.handleClose()}>
-                                Cancel
+                                Close
                             </Button>
                             <Button variant="primary" type='submit' disabled={isLoading}>
                                 { isLoading ? "Submitting..." : "Submit Copy Job" }

--- a/src/frontend/js/views/Dialogs/NewHashsumJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewHashsumJobDialog.jsx
@@ -151,7 +151,7 @@ class NewHashsumJobDialog extends React.Component {
                         </Modal.Body>
                         <Modal.Footer>
                             <Button variant="secondary" onClick={() => this.handleClose()}>
-                                Cancel
+                                Close
                             </Button>
                             <Button variant="primary" type='submit' disabled={isLoading}>
                                 { isLoading ? "Checking..." : "Check hashes" }

--- a/src/frontend/js/views/Dialogs/NewHashsumJobDialog.jsx
+++ b/src/frontend/js/views/Dialogs/NewHashsumJobDialog.jsx
@@ -15,7 +15,7 @@ class NewHashsumJobDialog extends React.Component {
     }
 
     render() {
-        const { data } = this.props;
+        const { data, isLoading } = this.props;
 
         return (
             <div className='dialog-integrity'>
@@ -153,8 +153,8 @@ class NewHashsumJobDialog extends React.Component {
                             <Button variant="secondary" onClick={() => this.handleClose()}>
                                 Cancel
                             </Button>
-                            <Button variant="primary" type='submit'>
-                                Check hashes
+                            <Button variant="primary" type='submit' disabled={isLoading}>
+                                { isLoading ? "Checking..." : "Check hashes" }
                             </Button>
                         </Modal.Footer>
                     </form>
@@ -206,6 +206,8 @@ class NewHashsumJobDialog extends React.Component {
 NewHashsumJobDialog.defaultProps = {
     data: {},
 
+    isLoading: false,
+
     followSymlinksDefault: false,
     doubleCheckDefault: false,
     emailNotificationsDefault: false,
@@ -223,16 +225,15 @@ import {createHashsumJob} from 'actions/apiActions.jsx'
 const mapStateToProps = state => ({
     data: state.dialog.newHashsumJobDialogData,
 
+    isLoading: state.loaders.createHashsumJobLoading,
+
     emailNotificationsDefault: state.settings.emailNotifications,
     emailAddressDefault: state.settings.emailAddress,
 });
 
 const mapDispatchToProps = dispatch => ({
     onClose: () => dispatch(hideNewHashsumJobDialog()),
-    onSubmit: data => {
-        dispatch(hideNewHashsumJobDialog())
-        dispatch(createHashsumJob(data))
-    }
+    onSubmit: data => dispatch(createHashsumJob(data)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(NewHashsumJobDialog);


### PR DESCRIPTION
Closes https://github.com/FredHutch/motuz/issues/337

This PR adds two new checks:

### 1. If the user already has a job that writes to the same destination and is in progress, the following popup will be shown

![Screen Shot 2020-11-16 at 00 08 22](https://user-images.githubusercontent.com/3248682/99227392-052cba00-27a0-11eb-8f74-9d3454131c23.png)


### 2. After the user clicks the Submit button for both the Copy Job and the Hashsum job, the submit button becomes disabled, leading to a better UX

| Before | After |
| --- | --- |
| ![Screen Shot 2020-11-16 at 00 05 37](https://user-images.githubusercontent.com/3248682/99227410-0a8a0480-27a0-11eb-9417-ab934ae34e6f.png) | ![Screen Shot 2020-11-16 at 00 05 47](https://user-images.githubusercontent.com/3248682/99227414-0bbb3180-27a0-11eb-9101-d8b53999598f.png) |
