### PR TITLE
attempt adding --contimeout=5m to rclone copy

### DIFF
--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -152,6 +152,7 @@ class RcloneConnection(AbstractConnection):
             '/usr/local/bin/rclone',
             '--config=/dev/null',
             option_exclude_dot_snapshot,
+            '--contimeout=5m',
             'copyto',
             src,
             dst,


### PR DESCRIPTION
Tested this on a development machine and simple copies worked ok. DId not try it with Swift or attempt to reproduce #344 . Maybe @scottsisco or @bmcgough can do that after this is deployed into prod.
