### PR TITLE
Added _TYPE to the allowed keys

### DIFF
--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -475,6 +475,9 @@ def should_log_full_credential(key):
     """
 
     suffix_allowlist = [
+        # generic
+        '_TYPE',
+
         # s3
         '_REGION',
         '_ENDPOINT',


### PR DESCRIPTION
Sample

```bash
RCLONE_CONFIG_DST_TYPE='s3' RCLONE_CONFIG_DST_REGION='us-west-2' RCLONE_CONFIG_DST_ACCESS_KEY_ID='***TURM' RCLONE_CONFIG_DST_SECRET_ACCESS_KEY='***' sudo -E -u aicioara /usr/local/bin/rclone --config=/dev/null copyto /Users/aicioara/tmp/11.blob dst:/motuz-test/11.blob --progress --stats 2s
```