### PR TITLE
Add support for AWS STS creds

### DIFF
--- a/src/backend/api/models/cloud_connection.py
+++ b/src/backend/api/models/cloud_connection.py
@@ -13,6 +13,7 @@ class CloudConnection(db.Model):
     owner = db.Column(db.String)
 
     type = db.Column(db.String)
+    subtype = db.Column(db.String, nullable=True)
     bucket = db.Column(db.String, nullable=True)
 
     # S3 fields

--- a/src/backend/api/models/cloud_connection.py
+++ b/src/backend/api/models/cloud_connection.py
@@ -18,6 +18,7 @@ class CloudConnection(db.Model):
     # S3 fields
     s3_access_key_id = db.Column(db.String, nullable=True)
     s3_secret_access_key = db.Column(db.String, nullable=True)
+    s3_session_token = db.Column(db.String, nullable=True)
     s3_region = db.Column(db.String, nullable=True)
 
     # S3 compatible fields

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -309,10 +309,11 @@ class RcloneConnection(AbstractConnection):
                 '{}_SECRET_ACCESS_KEY'.format(prefix),
                 's3_secret_access_key'
             )
-            _addCredential(
-                '{}_SESSION_TOKEN'.format(prefix),
-                's3_session_token'
-            )
+            if data.subtype == 'sts':
+                _addCredential(
+                    '{}_SESSION_TOKEN'.format(prefix),
+                    's3_session_token'
+                )
 
             _addCredential(
                 '{}_ENDPOINT'.format(prefix),
@@ -324,18 +325,20 @@ class RcloneConnection(AbstractConnection):
             )
 
         elif data.type == 'azureblob':
-            _addCredential(
-                '{}_ACCOUNT'.format(prefix),
-                'azure_account'
-            )
-            _addCredential(
-                '{}_KEY'.format(prefix),
-                'azure_key'
-            )
-            _addCredential(
-                '{}_SAS_URL'.format(prefix),
-                'azure_sas_url'
-            )
+            if data.subtype == 'sas':
+                _addCredential(
+                    '{}_SAS_URL'.format(prefix),
+                    'azure_sas_url'
+                )
+            else:
+                _addCredential(
+                    '{}_ACCOUNT'.format(prefix),
+                    'azure_account'
+                )
+                _addCredential(
+                    '{}_KEY'.format(prefix),
+                    'azure_key'
+                )
 
         elif data.type == 'swift':
             _addCredential(

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -309,6 +309,10 @@ class RcloneConnection(AbstractConnection):
                 '{}_SECRET_ACCESS_KEY'.format(prefix),
                 's3_secret_access_key'
             )
+            _addCredential(
+                '{}_SESSION_TOKEN'.format(prefix),
+                's3_session_token'
+            )
 
             _addCredential(
                 '{}_ENDPOINT'.format(prefix),

--- a/src/backend/api/views/cloud_connection_views.py
+++ b/src/backend/api/views/cloud_connection_views.py
@@ -32,6 +32,7 @@ dto = api.model('connection', {
 
     's3_access_key_id': fields.String(required=False, example='KJRHJKHWEIUJDSJKDC2J'),
     's3_secret_access_key': PrivateString(required=False, example='jksldASDLASdak+asdSDASDKjasldkjadASDAasd'),
+    's3_session_token': PrivateString(required=False, example='IQoJdlc3QtMiJHMEUCIH8EUqB/Qk2OEYpzejW6g9gi/'),
     's3_region': OptionalString(required=False, example='us-west-2'),
 
     's3_endpoint': OptionalString(required=False, example='https://hello.swiftstack.com'),

--- a/src/backend/api/views/cloud_connection_views.py
+++ b/src/backend/api/views/cloud_connection_views.py
@@ -28,6 +28,7 @@ dto = api.model('connection', {
     'name': fields.String(required=True, example='arbitrary-unique-name'),
 
     'type': fields.String(required=True, example='s3'),
+    'subtype': fields.String(required=False, example='key'),
     'bucket': OptionalString(required=False, example='my-bucket-name'),
 
     's3_access_key_id': fields.String(required=False, example='KJRHJKHWEIUJDSJKDC2J'),

--- a/src/backend/migrations/versions/20220122_114248_51633c8a4305_.py
+++ b/src/backend/migrations/versions/20220122_114248_51633c8a4305_.py
@@ -1,0 +1,24 @@
+"""add column
+
+Revision ID: 51633c8a4305
+Revises: 1d453219803e
+Create Date: 2022-01-22 11:42:48.734440
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '51633c8a4305'
+down_revision = '1d453219803e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('cloud_connection', sa.Column('s3_session_token', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('cloud_connection', 's3_session_token')

--- a/src/backend/migrations/versions/20220122_114248_51633c8a4305_.py
+++ b/src/backend/migrations/versions/20220122_114248_51633c8a4305_.py
@@ -17,8 +17,10 @@ depends_on = None
 
 
 def upgrade():
+    op.add_column('cloud_connection', sa.Column('subtype', sa.String(), nullable=True))
     op.add_column('cloud_connection', sa.Column('s3_session_token', sa.String(), nullable=True))
 
 
 def downgrade():
+    op.drop_column('cloud_connection', 'subtype')
     op.drop_column('cloud_connection', 's3_session_token')

--- a/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
@@ -78,6 +78,7 @@ class CloudConnectionDialogFields extends React.Component {
     render() {
         const { data, errors } = this.props;
         const type = this.state.type || this.props.data.type || 's3';
+        const subtype = this.state.subtype || this.props.data.subtype;
 
         return (
             <div className="container">
@@ -117,11 +118,11 @@ class CloudConnectionDialogFields extends React.Component {
                     isValid={this.props.verifySuccess}
                 />
 
-                {type === 's3' && this._renderS3Section()}
-                {type === 'azureblob' && this._renderAzureSection()}
+                {type === 's3' && this._renderS3Section(subtype)}
+                {type === 'azureblob' && this._renderAzureSection(subtype)}
                 {type === 'swift' && this._renderSwiftSection()}
                 {type === 'google cloud storage' && this._renderGCPSection()}
-                {type === 'sftp' && this._renderSFTPSection()}
+                {type === 'sftp' && this._renderSFTPSection(subtype)}
                 {type === 'dropbox' && this._renderDropboxSection()}
                 {type === 'onedrive' && this._renderOnedriveSection()}
                 {type === 'webdav' && this._renderWebdavSection()}
@@ -133,7 +134,7 @@ class CloudConnectionDialogFields extends React.Component {
 
     }
 
-    _renderS3Section() {
+    _renderS3Section(subtype) {
         return (
             <React.Fragment>
                 <CloudConnectionField
@@ -161,13 +162,13 @@ class CloudConnectionDialogFields extends React.Component {
                 />
                 <div className="row form-group required">
                     <div className="col-4 text-right control-label">
-                        <b className='form-label'>Connection Type</b>
+                        <b className='form-label'>S3 Connection Type</b>
                     </div>
                     <div className="col-8">
                         <select
                             className="form-control"
-                            // Do not specify "name", we do not want this in the request
-                            value={this.state.subtype}
+                            name="subtype"
+                            value={subtype}
                             onChange={(event => this.setState({subtype: event.target.value}))}
                         >
                             {S3_CONNECTION_TYPES.map(d => (
@@ -216,7 +217,7 @@ class CloudConnectionDialogFields extends React.Component {
                     isSanitized={this.props.isSanitized}
                 />
 
-                {this.state.subtype === 'sts' &&
+                {subtype === 'sts' &&
                     <CloudConnectionField
                         label='Session Token'
                         input={{
@@ -254,7 +255,7 @@ class CloudConnectionDialogFields extends React.Component {
         )
     }
 
-    _renderAzureSection() {
+    _renderAzureSection(subtype) {
         return (
             <React.Fragment>
                 <div className="row form-group required">
@@ -264,8 +265,8 @@ class CloudConnectionDialogFields extends React.Component {
                     <div className="col-8">
                         <select
                             className="form-control"
-                            // Do not specify "name", we do not want this in the request
-                            value={this.state.subtype}
+                            name="subtype"
+                            value={subtype}
                             onChange={(event => this.setState({subtype: event.target.value}))}
                         >
                             {AZURE_CONNECTION_TYPES.map(d => (
@@ -278,8 +279,8 @@ class CloudConnectionDialogFields extends React.Component {
                     </div>
                 </div>
 
-                {this.state.subtype === 'key' && this._renderAzureKeySubsection()}
-                {this.state.subtype === 'sas' && this._renderAzureSasSubsection()}
+                {subtype === 'key' && this._renderAzureKeySubsection()}
+                {subtype === 'sas' && this._renderAzureSasSubsection()}
             </React.Fragment>
         )
     }
@@ -469,7 +470,7 @@ class CloudConnectionDialogFields extends React.Component {
         )
     }
 
-    _renderSFTPSection() {
+    _renderSFTPSection(subtype) {
         return (
             <React.Fragment>
                 <CloudConnectionField
@@ -525,8 +526,8 @@ class CloudConnectionDialogFields extends React.Component {
                     <div className="col-8">
                         <select
                             className="form-control"
-                            // Do not specify "name", we do not want this in the request
-                            value={this.state.subtype}
+                            name="subtype"
+                            value={subtype}
                             onChange={(event => this.setState({subtype: event.target.value}))}
                         >
                             {SFTP_CONNECTION_TYPES.map(d => (
@@ -539,8 +540,8 @@ class CloudConnectionDialogFields extends React.Component {
                     </div>
                 </div>
 
-                {this.state.subtype === 'password' && this._renderSFTPPasswordSubsection()}
-                {this.state.subtype === 'key' && this._renderSFTPKeySubsection()}
+                {subtype === 'password' && this._renderSFTPPasswordSubsection()}
+                {subtype === 'key' && this._renderSFTPKeySubsection()}
 
 
             </React.Fragment>
@@ -783,7 +784,7 @@ CloudConnectionDialogFields.defaultProps = {
 
 CloudConnectionDialogFields.initialState = {
     type: '',
-    subtype: 'key',
+    subtype: '',
 }
 
 

--- a/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Modal, Button } from 'react-bootstrap'
 import classnames from 'classnames';
 
 const CONNECTION_TYPES = [
@@ -35,6 +34,17 @@ const CONNECTION_TYPES = [
         label: 'Microsoft OneDrive (beta)',
         value: 'onedrive',
     },
+]
+
+const S3_CONNECTION_TYPES = [
+    {
+        label: 'Access Key Credentials',
+        value: 'key'
+    },
+    {
+        label: 'Temporary Security Credentials (STS)',
+        key: 'sts'
+    }
 ]
 
 const AZURE_CONNECTION_TYPES = [
@@ -149,11 +159,31 @@ class CloudConnectionDialogFields extends React.Component {
                     error={this.props.errors.s3_region}
                     isValid={this.props.verifySuccess}
                 />
+                <div className="row form-group required">
+                    <div className="col-4 text-right control-label">
+                        <b className='form-label'>Connection Type</b>
+                    </div>
+                    <div className="col-8">
+                        <select
+                            className="form-control"
+                            // Do not specify "name", we do not want this in the request
+                            value={this.state.subtype}
+                            onChange={(event => this.setState({subtype: event.target.value}))}
+                        >
+                            {S3_CONNECTION_TYPES.map(d => (
+                                <option
+                                    key={d.value}
+                                    value={d.value}
+                                >{d.label}</option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
 
                 <h5 className='text-primary mt-5 mb-2'>Credentials</h5>
 
                 <CloudConnectionField
-                    label='access_key_id'
+                    label='Access Key ID'
                     input={{
                         name: 's3_access_key_id',
                         defaultValue: this.props.data.s3_access_key_id,
@@ -169,7 +199,7 @@ class CloudConnectionDialogFields extends React.Component {
                 />
 
                 <CloudConnectionField
-                    label='secret_access_key'
+                    label='Secret Access Key'
                     input={{
                         name: 's3_secret_access_key',
                         defaultValue: this.props.data.s3_secret_access_key,
@@ -185,6 +215,24 @@ class CloudConnectionDialogFields extends React.Component {
                     isValid={this.props.verifySuccess}
                     isSanitized={this.props.isSanitized}
                 />
+
+                {this.state.subtype === 'sts' &&
+                    <CloudConnectionField
+                        label='Session Token'
+                        input={{
+                            name: 's3_session_token',
+                            defaultValue: this.props.data.s3_session_token,
+                            title: "Must be a valid AWS Session Token",
+                            required: true,
+                            type: 'password',
+                            minLength: 40,
+                            pattern: "^([A-Za-z0-9/+=]*)$"
+                        }}
+                        error={this.props.errors.s3_session_token}
+                        isValid={this.props.verifySuccess}
+                        isSanitized={this.props.isSanitized}
+                    />
+                }
 
                 <details>
                     <summary className='text-primary h5 mt-5 mb-2'>
@@ -714,9 +762,11 @@ class CloudConnectionDialogFields extends React.Component {
 
     onTypeChange(type) {
         let {subtype} = this.state
-        if (type == 'sftp') {
+        if (type === 'sftp') {
             subtype = 'password'
-        } else if (type == 'azureblob') {
+        } else if (type === 'azureblob') {
+            subtype = 'key'
+        } else if (type === 's3') {
             subtype = 'key'
         }
 

--- a/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
+++ b/src/frontend/js/views/Dialogs/CloudConnection/CloudConnectionDialogFields.jsx
@@ -43,7 +43,7 @@ const S3_CONNECTION_TYPES = [
     },
     {
         label: 'Temporary Security Credentials (STS)',
-        key: 'sts'
+        value: 'sts'
     }
 ]
 


### PR DESCRIPTION
Adds support for an S3 credential if you have a session token (from STS). This is useful if you get temporary credentials from a provider.

Don't know if it would be better to have the connection type dropdown for this (like in Azure) or just have the session token be an optional field. It is currently implemented as a dropdown option.

Save subtype into the database so users can edit connections that have multiple methods (S3, Azure Blob, and SFTP).

![image](https://user-images.githubusercontent.com/889094/171530490-d2cf6f40-6ef1-4547-af5f-95206af851a5.png)

![image](https://user-images.githubusercontent.com/889094/171530526-1f22ebfa-d94d-4a17-86b2-1100685befc6.png)
