### PR TITLE
Remove workaround for md5sum download

### DIFF
--- a/deployment/docker/app/Dockerfile
+++ b/deployment/docker/app/Dockerfile
@@ -37,10 +37,10 @@ RUN set -x \
         sudo \
         curl \
         unzip \
-    && curl -LO https://downloads.rclone.org/v1.47.0/rclone-v1.47.0-linux-amd64.zip \
-    && unzip rclone-v1.47.0-linux-amd64.zip \
-    && cp rclone-v1.47.0-linux-amd64/rclone /usr/local/bin/ \
-    && rm -rf rclone-v1.47.0-linux-amd64.zip rclone-v1.47.0-linux-amd64/ \
+    && curl -LO https://downloads.rclone.org/v1.58.1/rclone-v1.58.1-linux-amd64.zip \
+    && unzip rclone-v1.58.1-linux-amd64.zip \
+    && cp rclone-v1.58.1-linux-amd64/rclone /usr/local/bin/ \
+    && rm -rf rclone-v1.58.1-linux-amd64.zip rclone-v1.58.1-linux-amd64/ \
     && apt-get remove --purge --auto-remove -y \
         unzip \
         curl \

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -110,37 +110,6 @@ class HashsumJobQueue:
             })
             self.__process_copy_status(job_id)
 
-
-        if download:
-            user = command[command.index('-u') + 1]
-            base = command[-1]
-            if base[:4] != 'src:':
-                raise RuntimeError("Could not perform download of file. Incorrect base `{}`".format(base))
-            base = '/' + base[4:]
-
-            for file in self._job_status[job_id]:
-                stored_checksum = file['md5chksum']
-                file['md5chksum'] = 'CHECKING_VALUE..._______________'
-                file_path_clean = shlex.quote(os.path.join(os.path.dirname(base), file['Name']))
-                command = [
-                    'sudo',
-                    '-E',
-                    '-u', shlex.quote(user),
-                    '/usr/local/bin/rclone',
-                    '--config=/dev/null',
-                    'cat',
-                    'src:{}'.format(file_path_clean),
-                ]
-                command = ' '.join(command) + " | md5sum"
-                # TODO: Remove this hack once https://github.com/rclone/rclone/issues/3923 is addressed
-                md5sum = subprocess.check_output(command, env=full_env, shell=True).decode('utf-8')[:32]
-                if stored_checksum and md5sum != stored_checksum:
-                    file['md5chksum'] = 'FILE_IS_CORRUPTED!!!____________'
-                else:
-                    file['md5chksum'] = md5sum
-                self.__process_copy_status(job_id)
-
-
         self._job_percent[job_id] = 100
         self.__process_copy_status(job_id)
 

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import shlex
 import subprocess
 import threading
 import time

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -73,7 +73,7 @@ class HashsumJobQueue:
         thread.start()
 
 
-    def __execute_interactive(self, command, env, job_id, download):
+    def __execute_interactive(self, command, env, job_id):
         stop_event = self._stop_events[job_id]
         full_env = os.environ.copy()
         full_env.update(env)

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -1,14 +1,14 @@
-from collections import defaultdict
-import functools
-import json
 import logging
+import os
 import re
+import shlex
 import subprocess
 import threading
 import time
-import os
+from collections import defaultdict
 
-from .abstract_connection import AbstractConnection, RcloneException
+from .abstract_connection import RcloneException
+
 
 class HashsumJobQueue:
     def __init__(self):
@@ -121,14 +121,15 @@ class HashsumJobQueue:
             for file in self._job_status[job_id]:
                 stored_checksum = file['md5chksum']
                 file['md5chksum'] = 'CHECKING_VALUE..._______________'
+                file_path_clean = shlex.quote(os.path.join(os.path.dirname(base), file['Name']))
                 command = [
                     'sudo',
                     '-E',
-                    '-u', user,
+                    '-u', shlex.quote(user),
                     '/usr/local/bin/rclone',
                     '--config=/dev/null',
                     'cat',
-                    'src:{}'.format(os.path.join(os.path.dirname(base), file['Name'])),
+                    'src:{}'.format(file_path_clean),
                 ]
                 command = ' '.join(command) + " | md5sum"
                 # TODO: Remove this hack once https://github.com/rclone/rclone/issues/3923 is addressed

--- a/src/backend/api/utils/hashsum_job_queue.py
+++ b/src/backend/api/utils/hashsum_job_queue.py
@@ -21,14 +21,14 @@ class HashsumJobQueue:
         self._stop_events = {} # Mapping from id to threading.Event
 
 
-    def push(self, command, env, job_id, download):
+    def push(self, command, env, job_id):
         if self._job_id_exists(job_id):
             raise KeyError("Job with ID {} already submitted to {}".format(job_id, self.__class__))
 
         self._stop_events[job_id] = threading.Event()
 
         try:
-            self._execute_interactive(command, env, job_id, download)
+            self._execute_interactive(command, env, job_id)
         except subprocess.CalledProcessError as e:
             raise RcloneException(e)
 
@@ -62,12 +62,11 @@ class HashsumJobQueue:
         return job_id in self._job_status
 
 
-    def _execute_interactive(self, command, env, job_id, download):
+    def _execute_interactive(self, command, env, job_id):
         thread = threading.Thread(target=self.__execute_interactive, kwargs={
             'command': command,
             'env': env,
-            'job_id': job_id,
-            'download': download,
+            'job_id': job_id
         })
         thread.daemon = True
         thread.start()

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -232,7 +232,7 @@ class RcloneConnection(AbstractConnection):
         self._log_command(command, credentials)
 
         try:
-            self._hashsum_job_queue.push(command, credentials, job_id, download)
+            self._hashsum_job_queue.push(command, credentials, job_id)
         except RcloneException as e:
             raise RcloneException(str(e))
 

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -150,6 +150,7 @@ class RcloneConnection(AbstractConnection):
             '/usr/local/bin/rclone',
             '--config=/dev/null',
             '--s3-acl',
+            '--s3-no-check-bucket',
             'bucket-owner-full-control',
             option_exclude_dot_snapshot,
             '--contimeout=5m',

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -202,6 +202,7 @@ class RcloneConnection(AbstractConnection):
     ):
         credentials = {}
         option_exclude_dot_snapshot = '' # HACKHACK: remove once https://github.com/rclone/rclone/issues/2425 is addressed
+        option_download = ''
 
         if data is None: # Local
             src = resource_path
@@ -212,6 +213,9 @@ class RcloneConnection(AbstractConnection):
             credentials.update(self._formatCredentials(data, name='src'))
             src = 'src:{}'.format(resource_path)
 
+        if download:
+            option_download = '--download'
+
         command = [
             'sudo',
             '-E',
@@ -221,6 +225,7 @@ class RcloneConnection(AbstractConnection):
             'md5sum',
             src,
             option_exclude_dot_snapshot,
+            option_download
         ]
 
         command = [cmd for cmd in command if len(cmd) > 0]

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -1,15 +1,14 @@
-from collections import defaultdict
 import functools
 import json
 import logging
-import subprocess
-import threading
-import time
 import os
+import subprocess
+from collections import defaultdict
 
 from .abstract_connection import AbstractConnection, RcloneException
-from .hashsum_job_queue import HashsumJobQueue
 from .copy_job_queue import CopyJobQueue
+from .hashsum_job_queue import HashsumJobQueue
+
 
 class RcloneConnection(AbstractConnection):
     def __init__(self):


### PR DESCRIPTION
Resolves #297 and #371

- Bump rclone to 1.58.1 to pick up the `--download` flag on the `rclone md5sum` command
- Fix potential command injection with the workaround (file names are not escaped)