### PR TITLE
start celery pool with concurrency == number of cpus * 3

### DIFF
--- a/deployment/docker/celery/celery-entrypoint.sh
+++ b/deployment/docker/celery/celery-entrypoint.sh
@@ -7,4 +7,8 @@ set -e
 
 source ./load-secrets.sh
 
-celery -A api.tasks worker -l info
+CPU_COUNT=$(grep processor /proc/cpuinfo | wc -l)
+CONCURRENCY=$(($CPU_COUNT*3))
+
+celery -A api.tasks worker -l info --concurrency $CONCURRENCY
+


### PR DESCRIPTION
Since our jobs are IO-bound they are not CPU intensive and we can make the pool deeper.

For reference, pool size can be increased at runtime by docker exec'ing into the celery container and running:

```
source ./load-secrets.sh
celery -A api.tasks control pool_grow 20 # adds 20 to current size
```