### PR TITLE
add -s3-disable-checksum to rclone copyto command

### DIFF
--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -150,6 +150,7 @@ class RcloneConnection(AbstractConnection):
             '-u', user,
             '/usr/local/bin/rclone',
             '--config=/dev/null',
+            '-s3-disable-checksum',
             '--s3-acl',
             'bucket-owner-full-control',
             option_exclude_dot_snapshot,

--- a/src/backend/api/utils/rclone_connection.py
+++ b/src/backend/api/utils/rclone_connection.py
@@ -150,7 +150,7 @@ class RcloneConnection(AbstractConnection):
             '-u', user,
             '/usr/local/bin/rclone',
             '--config=/dev/null',
-            '-s3-disable-checksum',
+            '--s3-disable-checksum',
             '--s3-acl',
             'bucket-owner-full-control',
             option_exclude_dot_snapshot,


### PR DESCRIPTION
Now rclone will not try to compute checksums before uploading to S3. See https://rclone.org/s3/#s3-disable-checksum