### PR TITLE
refactor so that jobs are launched in separate docker containers

### DIFF
--- a/deployment/docker/celery/Dockerfile
+++ b/deployment/docker/celery/Dockerfile
@@ -3,6 +3,38 @@
 
 FROM fredhutch/motuz_app:latest
 
+RUN echo "deb http://archive.debian.org/debian stretch main contrib non-free" > /etc/apt/sources.list
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -x \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+       ca-certificates curl gnupg apt-transport-https lsb-release
+
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN chmod a+r /etc/apt/keyrings/docker.gpg
+
+RUN echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  "$(lcurl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpgsb_release -c -s)" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+
+RUN apt-get update -y
+
+RUN apt-get install -y docker-ce docker-ce-cli containerd.io # docker-buildx-plugin docker-compose-plugin
+
+RUN python3.7 -m pip install docker
+
+RUN python3.7  -m pip uninstall -y urllib3
+RUN python3.7 -m pip install urllib3==1.26.16
+
+
+
+
+
 COPY ./deployment/docker/celery/celery-entrypoint.sh /app/src/backend/
 
 WORKDIR /app/src/backend


### PR DESCRIPTION
This is just getting started but I made it a draft PR so that it does not get lost in the sea of branches.

Basically the goal is to make it so that the motuz core containers can be restarted at any time (to deploy code updates, etc) without interrupting running jobs. 

The way to do this is to make each copy/check job a separate docker container. You can launch a container within a container if you have Docker installed in the container and /var/lib/docker.sock on the host is mounted to /var/lib/docker.sock in the container.

The child container that gets launched needs to mount the same filesystems as its parent, but this is easy to figure out programmatically using the Docker API.

I've modified the celery container to have docker installed. But there is still a lot more to do:

* Have a think about whether the celery container still needs to exist? If it is restarted, it will forget about running jobs. Jobs already phone in to the database so maybe the web app container (not the celery container) can launch jobs, and we just use the database to see what jobs are in flight? This needs plenty of testing....
